### PR TITLE
Unhook virtual functions when friendly fire is disabled

### DIFF
--- a/addons/sourcemod/scripting/friendlyfire.sp
+++ b/addons/sourcemod/scripting/friendlyfire.sp
@@ -25,7 +25,7 @@
 #include <tf2_stocks>
 #include <tf2utils>
 
-#define PLUGIN_VERSION	"1.0.0"
+#define PLUGIN_VERSION	"1.0.1"
 
 #define TICK_NEVER_THINK	-1.0
 


### PR DESCRIPTION
Forgot to do this in the initial release.

Bumps version to 1.0.1.