### PR TITLE
Fix entities not being hooked when friendly fire gets enabled mid-game

### DIFF
--- a/addons/sourcemod/scripting/friendlyfire.sp
+++ b/addons/sourcemod/scripting/friendlyfire.sp
@@ -154,12 +154,7 @@ public void OnClientPutInServer(int client)
 
 public void OnEntityCreated(int entity, const char[] classname)
 {
-	// Always hook entities, just so we don't have to unhook and re-hook everything
 	SDKHooks_OnEntityCreated(entity, classname);
-	
-	if (!g_isEnabled)
-		return;
-	
 	DHooks_OnEntityCreated(entity, classname);
 }
 

--- a/addons/sourcemod/scripting/friendlyfire.sp
+++ b/addons/sourcemod/scripting/friendlyfire.sp
@@ -25,7 +25,7 @@
 #include <tf2_stocks>
 #include <tf2utils>
 
-#define PLUGIN_VERSION	"1.0.2"
+#define PLUGIN_VERSION	"1.0.3"
 
 #define TICK_NEVER_THINK	-1.0
 
@@ -79,6 +79,7 @@ enum
 ConVar mp_friendlyfire;
 
 bool g_isEnabled;
+bool g_isMapRunning;
 
 #include "friendlyfire/convars.sp"
 #include "friendlyfire/data.sp"
@@ -116,6 +117,16 @@ public void OnPluginStart()
 	}
 }
 
+public void OnMapStart()
+{
+	g_isMapRunning = true;
+}
+
+public void OnMapEnd()
+{
+	g_isMapRunning = false;
+}
+
 public void OnConfigsExecuted()
 {
 	if (g_isEnabled != mp_friendlyfire.BoolValue)
@@ -129,7 +140,7 @@ public void OnPluginEnd()
 	if (!g_isEnabled)
 		return;
 	
-	TogglePlugin(!g_isEnabled);
+	TogglePlugin(false);
 }
 
 public void OnClientPutInServer(int client)
@@ -143,7 +154,7 @@ public void OnClientPutInServer(int client)
 
 public void OnEntityCreated(int entity, const char[] classname)
 {
-	if (!g_isEnabled)
+	if (!g_isEnabled || !g_isMapRunning)
 		return;
 	
 	DHooks_OnEntityCreated(entity, classname);

--- a/addons/sourcemod/scripting/friendlyfire.sp
+++ b/addons/sourcemod/scripting/friendlyfire.sp
@@ -115,6 +115,16 @@ public void OnPluginStart()
 	{
 		SetFailState("Could not find friendlyfire gamedata");
 	}
+	
+	int entity = -1;
+	while ((entity = FindEntityByClassname(entity, "*")) != -1)
+	{
+		char classname[64];
+		if (GetEntityClassname(entity, classname, sizeof(classname)))
+		{
+			OnEntityCreated(entity, classname);
+		}
+	}
 }
 
 public void OnMapStart()

--- a/addons/sourcemod/scripting/friendlyfire.sp
+++ b/addons/sourcemod/scripting/friendlyfire.sp
@@ -154,6 +154,7 @@ public void OnClientPutInServer(int client)
 
 public void OnEntityCreated(int entity, const char[] classname)
 {
+	// Always hook entities, just so we don't have to unhook and re-hook everything
 	SDKHooks_OnEntityCreated(entity, classname);
 	
 	if (!g_isEnabled)

--- a/addons/sourcemod/scripting/friendlyfire.sp
+++ b/addons/sourcemod/scripting/friendlyfire.sp
@@ -154,11 +154,12 @@ public void OnClientPutInServer(int client)
 
 public void OnEntityCreated(int entity, const char[] classname)
 {
-	if (!g_isEnabled || !g_isMapRunning)
+	SDKHooks_OnEntityCreated(entity, classname);
+	
+	if (!g_isEnabled)
 		return;
 	
 	DHooks_OnEntityCreated(entity, classname);
-	SDKHooks_OnEntityCreated(entity, classname);
 }
 
 public void OnEntityDestroyed(int entity)

--- a/addons/sourcemod/scripting/friendlyfire.sp
+++ b/addons/sourcemod/scripting/friendlyfire.sp
@@ -164,8 +164,8 @@ public void OnClientPutInServer(int client)
 
 public void OnEntityCreated(int entity, const char[] classname)
 {
-	SDKHooks_OnEntityCreated(entity, classname);
 	DHooks_OnEntityCreated(entity, classname);
+	SDKHooks_OnEntityCreated(entity, classname);
 }
 
 public void OnEntityDestroyed(int entity)

--- a/addons/sourcemod/scripting/friendlyfire/dhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/dhooks.sp
@@ -122,46 +122,46 @@ void DHooks_OnEntityCreated(int entity, const char[] classname)
 		// Fixes jars not applying effects to teammates when hitting the world
 		if (strncmp(classname, "tf_projectile_jar", 17) == 0)
 		{
-			DHooks_HookEntity(g_dhookBaseGrenadeExplode, Hook_Pre, entity, DHookCallback_BaseGrenadeExplode_Pre);
-			DHooks_HookEntity(g_dhookBaseGrenadeExplode, Hook_Post, entity, DHookCallback_BaseGrenadeExplode_Post);
+			g_dhookBaseGrenadeExplode.HookEntity(Hook_Pre, entity, DHookCallback_BaseGrenadeExplode_Pre);
+			g_dhookBaseGrenadeExplode.HookEntity(Hook_Post, entity, DHookCallback_BaseGrenadeExplode_Post);
 		}
 		
 		// Fixes Scorch Shot knockback on teammates
 		if (StrEqual(classname, "tf_projectile_flare"))
 		{
-			DHooks_HookEntity(g_dhookBaseRocketExplode, Hook_Pre, entity, DHookCallback_BaseRocketExplode_Pre);
-			DHooks_HookEntity(g_dhookBaseRocketExplode, Hook_Post, entity, DHookCallback_BaseRocketExplode_Post);
+			g_dhookBaseRocketExplode.HookEntity(Hook_Pre, entity, DHookCallback_BaseRocketExplode_Pre);
+			g_dhookBaseRocketExplode.HookEntity(Hook_Post, entity, DHookCallback_BaseRocketExplode_Post);
 		}
 		
 		// Fixes grenades rarely bouncing off friendly objects
 		if (IsProjectileCTFWeaponBaseGrenade(entity))
 		{
-			DHooks_HookEntity(g_dhookVPhysicsUpdate, Hook_Pre, entity, DHookCallback_VPhysicsUpdate_Pre);
-			DHooks_HookEntity(g_dhookVPhysicsUpdate, Hook_Post, entity, DHookCallback_VPhysicsUpdate_Post);
+			g_dhookVPhysicsUpdate.HookEntity(Hook_Pre, entity, DHookCallback_VPhysicsUpdate_Pre);
+			g_dhookVPhysicsUpdate.HookEntity(Hook_Post, entity, DHookCallback_VPhysicsUpdate_Post);
 		}
 		
 		// Fixes projectiles sometimes not colliding with teammates
-		DHooks_HookEntity(g_dhookCanCollideWithTeammates, Hook_Post, entity, DHookCallback_CanCollideWithTeammates_Post);
+		g_dhookCanCollideWithTeammates.HookEntity(Hook_Post, entity, DHookCallback_CanCollideWithTeammates_Post);
 	}
 	
 	// Fixes Sniper Rifles dealing no damage to teammates
 	if (strncmp(classname, "tf_weapon_sniperrifle", 21) == 0)
 	{
-		DHooks_HookEntity(g_dhookGetCustomDamageType, Hook_Post, entity, DHookCallback_GetCustomDamageType_Post);
+		g_dhookGetCustomDamageType.HookEntity(Hook_Post, entity, DHookCallback_GetCustomDamageType_Post);
 	}
 	
 	// Fixes pipebomb launchers not being able to knock around friendly pipebombs
 	if (TF2Util_IsEntityWeapon(entity) && TF2Util_GetWeaponID(entity) == TF_WEAPON_PIPEBOMBLAUNCHER)
 	{
-		DHooks_HookEntity(g_dhookSecondaryAttack, Hook_Pre, entity, DHookCallback_SecondaryAttack_Pre);
-		DHooks_HookEntity(g_dhookSecondaryAttack, Hook_Post, entity, DHookCallback_SecondaryAttack_Post);
+		g_dhookSecondaryAttack.HookEntity(Hook_Pre, entity, DHookCallback_SecondaryAttack_Pre);
+		g_dhookSecondaryAttack.HookEntity(Hook_Post, entity, DHookCallback_SecondaryAttack_Post);
 	}
 	
 	// Fixes wrenches not being able to upgrade friendly objects and a few other melee weapons
 	if (IsWeaponBaseMelee(entity))
 	{
-		DHooks_HookEntity(g_dhookSmack, Hook_Pre, entity, DHookCallback_Smack_Pre);
-		DHooks_HookEntity(g_dhookSmack, Hook_Post, entity, DHookCallback_Smack_Post);
+		g_dhookSmack.HookEntity(Hook_Pre, entity, DHookCallback_Smack_Pre);
+		g_dhookSmack.HookEntity(Hook_Post, entity, DHookCallback_Smack_Post);
 	}
 }
 
@@ -217,7 +217,7 @@ public void DHookRemovalCB_OnHookRemoved(int hookid)
 
 static MRESReturn DHookCallback_EventKilled_Pre(int player, DHookParam params)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!IsFriendlyFireEnabled())
 		return MRES_Ignored;
 	
 	// Switch back to the original team to force proper skin for ragdolls and other on-death effects
@@ -228,7 +228,7 @@ static MRESReturn DHookCallback_EventKilled_Pre(int player, DHookParam params)
 
 static MRESReturn DHookCallback_EventKilled_Post(int player, DHookParam params)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!IsFriendlyFireEnabled())
 		return MRES_Ignored;
 	
 	Entity(player).ResetTeam();
@@ -238,7 +238,7 @@ static MRESReturn DHookCallback_EventKilled_Post(int player, DHookParam params)
 
 static MRESReturn DHookCallback_BaseGrenadeExplode_Pre(int entity, DHookParam params)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!IsFriendlyFireEnabled())
 		return MRES_Ignored;
 	
 	int thrower = GetEntPropEnt(entity, Prop_Send, "m_hThrower");
@@ -253,7 +253,7 @@ static MRESReturn DHookCallback_BaseGrenadeExplode_Pre(int entity, DHookParam pa
 
 static MRESReturn DHookCallback_BaseGrenadeExplode_Post(int entity, DHookParam params)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!IsFriendlyFireEnabled())
 		return MRES_Ignored;
 	
 	int thrower = GetEntPropEnt(entity, Prop_Send, "m_hThrower");
@@ -268,7 +268,7 @@ static MRESReturn DHookCallback_BaseGrenadeExplode_Post(int entity, DHookParam p
 
 static MRESReturn DHookCallback_BaseRocketExplode_Pre(int entity, DHookParam params)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!IsFriendlyFireEnabled())
 		return MRES_Ignored;
 	
 	int other = params.Get(2);
@@ -280,7 +280,7 @@ static MRESReturn DHookCallback_BaseRocketExplode_Pre(int entity, DHookParam par
 
 static MRESReturn DHookCallback_BaseRocketExplode_Post(int entity, DHookParam params)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!IsFriendlyFireEnabled())
 		return MRES_Ignored;
 	
 	int other = params.Get(2);
@@ -292,7 +292,7 @@ static MRESReturn DHookCallback_BaseRocketExplode_Post(int entity, DHookParam pa
 
 static MRESReturn DHookCallback_CanCollideWithTeammates_Post(int entity, DHookReturn ret)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!IsFriendlyFireEnabled())
 		return MRES_Ignored;
 	
 	// Always make projectiles collide with teammates
@@ -303,7 +303,7 @@ static MRESReturn DHookCallback_CanCollideWithTeammates_Post(int entity, DHookRe
 
 static MRESReturn DHookCallback_GetCustomDamageType_Post(int entity, DHookReturn ret)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!IsFriendlyFireEnabled())
 		return MRES_Ignored;
 	
 	// Allows Sniper Rifles to hit teammates, without breaking Machina penetration
@@ -319,7 +319,7 @@ static MRESReturn DHookCallback_GetCustomDamageType_Post(int entity, DHookReturn
 
 static MRESReturn DHookCallback_Smack_Pre(int entity)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!IsFriendlyFireEnabled())
 		return MRES_Ignored;
 	
 	int owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
@@ -346,7 +346,7 @@ static MRESReturn DHookCallback_Smack_Pre(int entity)
 
 static MRESReturn DHookCallback_Smack_Post(int entity)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!IsFriendlyFireEnabled())
 		return MRES_Ignored;
 	
 	int owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
@@ -372,7 +372,7 @@ static MRESReturn DHookCallback_Smack_Post(int entity)
 
 static MRESReturn DHook_InSameTeam_Pre(int entity, DHookReturn ret, DHookParam params)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!IsFriendlyFireEnabled())
 		return MRES_Ignored;
 	
 	char classname[64];
@@ -411,7 +411,7 @@ static MRESReturn DHook_InSameTeam_Pre(int entity, DHookReturn ret, DHookParam p
 
 static MRESReturn DHookCallback_PhysicsDispatchThink_Pre(int entity)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!IsFriendlyFireEnabled())
 		return MRES_Ignored;
 	
 	char classname[64];
@@ -521,7 +521,7 @@ static MRESReturn DHookCallback_PhysicsDispatchThink_Pre(int entity)
 
 static MRESReturn DHookCallback_PhysicsDispatchThink_Post(int entity)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!IsFriendlyFireEnabled())
 		return MRES_Ignored;
 	
 	switch (g_thinkFunction)
@@ -600,7 +600,7 @@ static MRESReturn DHookCallback_PhysicsDispatchThink_Post(int entity)
 
 static MRESReturn DHookCallback_SecondaryAttack_Pre(int weapon)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!IsFriendlyFireEnabled())
 		return MRES_Ignored;
 	
 	// Switch the weapon
@@ -628,7 +628,7 @@ static MRESReturn DHookCallback_SecondaryAttack_Pre(int weapon)
 
 static MRESReturn DHookCallback_SecondaryAttack_Post(int weapon)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!IsFriendlyFireEnabled())
 		return MRES_Ignored;
 	
 	Entity(weapon).ResetTeam();
@@ -653,7 +653,7 @@ static MRESReturn DHookCallback_SecondaryAttack_Post(int weapon)
 
 static MRESReturn DHookCallback_VPhysicsUpdate_Pre(int entity, DHookParam params)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!IsFriendlyFireEnabled())
 		return MRES_Ignored;
 	
 	int thrower = GetEntPropEnt(entity, Prop_Send, "m_hThrower");
@@ -683,7 +683,7 @@ static MRESReturn DHookCallback_VPhysicsUpdate_Pre(int entity, DHookParam params
 
 static MRESReturn DHookCallback_VPhysicsUpdate_Post(int entity, DHookParam params)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!IsFriendlyFireEnabled())
 		return MRES_Ignored;
 	
 	int thrower = GetEntPropEnt(entity, Prop_Send, "m_hThrower");

--- a/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
@@ -47,13 +47,13 @@ int g_enemyItemIDs[] =
 	TF_WEAPON_GRAPPLINGHOOK,			// CTFGrapplingHook::ActivateRune
 };
 
-static ArrayList g_sdkHookData;
+static ArrayList g_clientHookData;
 static PostThinkType g_postThinkType;
 static RoundState g_roundState;
 
 void SDKHooks_Initialize()
 {
-	g_sdkHookData = new ArrayList(sizeof(SDKHookData));
+	g_clientHookData = new ArrayList(sizeof(SDKHookData));
 	
 	SDKHooks_AddHook(SDKHook_PreThink, SDKHookCB_Client_PreThink);
 	SDKHooks_AddHook(SDKHook_PreThinkPost, SDKHookCB_Client_PreThinkPost);
@@ -66,10 +66,10 @@ void SDKHooks_Initialize()
 
 void SDKHooks_OnClientPutInServer(int client)
 {
-	for (int i = 0; i < g_sdkHookData.Length; i++)
+	for (int i = 0; i < g_clientHookData.Length; i++)
 	{
 		SDKHookData data;
-		if (g_sdkHookData.GetArray(i, data))
+		if (g_clientHookData.GetArray(i, data))
 		{
 			SDKHook(client, data.type, data.callback);
 		}
@@ -78,10 +78,10 @@ void SDKHooks_OnClientPutInServer(int client)
 
 void SDKHooks_UnhookClient(int client)
 {
-	for (int i = 0; i < g_sdkHookData.Length; i++)
+	for (int i = 0; i < g_clientHookData.Length; i++)
 	{
 		SDKHookData data;
-		if (g_sdkHookData.GetArray(i, data))
+		if (g_clientHookData.GetArray(i, data))
 		{
 			SDKUnhook(client, data.type, data.callback);
 		}
@@ -137,7 +137,7 @@ static void SDKHooks_AddHook(SDKHookType type, SDKHookCB callback)
 	data.type = type;
 	data.callback = callback;
 	
-	g_sdkHookData.PushArray(data);
+	g_clientHookData.PushArray(data);
 }
 
 // CTFPlayerShared::OnPreDataChanged
@@ -204,12 +204,12 @@ static void SDKHookCB_Client_PostThink(int client)
 		// Don't let losing team attack with those weapons
 		if (GameRules_GetRoundState() == RoundState_TeamWin && TF2_GetClientTeam(client) != view_as<TFTeam>(GameRules_GetProp("m_iWinningTeam")))
 			break;
-
+		
 		if (TF2Util_GetWeaponID(activeWeapon) == g_spectatorItemIDs[i])
 		{
 			g_postThinkType = PostThinkType_Spectator;
 			g_roundState = GameRules_GetRoundState();
-
+			
 			RoundState state = (GameRules_GetProp("m_nGameType") == TF_GAMETYPE_ARENA) ? RoundState_Stalemate : RoundState_RoundRunning;
 			GameRules_SetProp("m_iRoundState", view_as<int>(state));
 			Entity(client).ChangeToSpectator();
@@ -296,7 +296,7 @@ static Action SDKHookCB_Client_SetTransmit(int entity, int client)
 
 static Action SDKHookCB_ObjectDispenser_StartTouch(int entity, int other)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!g_isEnabled || GameRules_GetProp("m_bTruceActive"))
 		return Plugin_Continue;
 	
 	if (IsEntityClient(other) && !IsObjectFriendly(entity, other))
@@ -309,7 +309,7 @@ static Action SDKHookCB_ObjectDispenser_StartTouch(int entity, int other)
 
 static void SDKHookCB_ObjectDispenser_StartTouchPost(int entity, int other)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!g_isEnabled || GameRules_GetProp("m_bTruceActive"))
 		return;
 	
 	if (IsEntityClient(other) && !IsObjectFriendly(entity, other))
@@ -320,7 +320,7 @@ static void SDKHookCB_ObjectDispenser_StartTouchPost(int entity, int other)
 
 static void SDKHookCB_Object_SpawnPost(int entity)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!g_isEnabled || !g_isMapRunning || GameRules_GetProp("m_bTruceActive"))
 		return;
 	
 	// Enable collisions for both teams
@@ -330,7 +330,7 @@ static void SDKHookCB_Object_SpawnPost(int entity)
 
 static Action SDKHookCB_Projectile_Touch(int entity, int other)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!g_isEnabled || GameRules_GetProp("m_bTruceActive"))
 		return Plugin_Continue;
 	
 	if (other == 0)
@@ -348,7 +348,7 @@ static Action SDKHookCB_Projectile_Touch(int entity, int other)
 
 static void SDKHookCB_Projectile_TouchPost(int entity, int other)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!g_isEnabled || GameRules_GetProp("m_bTruceActive"))
 		return;
 	
 	if (other == 0)
@@ -364,7 +364,7 @@ static void SDKHookCB_Projectile_TouchPost(int entity, int other)
 
 static Action SDKHookCB_ProjectilePipeRemote_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!g_isEnabled || GameRules_GetProp("m_bTruceActive"))
 		return Plugin_Continue;
 	
 	if (attacker != -1)
@@ -382,7 +382,7 @@ static Action SDKHookCB_ProjectilePipeRemote_OnTakeDamage(int victim, int &attac
 
 static void SDKHookCB_ProjectilePipeRemote_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!g_isEnabled || GameRules_GetProp("m_bTruceActive"))
 		return;
 	
 	if (attacker != -1)
@@ -396,7 +396,7 @@ static void SDKHookCB_ProjectilePipeRemote_OnTakeDamagePost(int victim, int atta
 
 static Action SDKHookCB_FlameManager_Touch(int entity, int other)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!g_isEnabled || GameRules_GetProp("m_bTruceActive"))
 		return Plugin_Continue;
 	
 	int owner = FindParentOwnerEntity(entity);
@@ -411,7 +411,7 @@ static Action SDKHookCB_FlameManager_Touch(int entity, int other)
 
 static void SDKHookCB_FlameManager_TouchPost(int entity, int other)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!g_isEnabled || GameRules_GetProp("m_bTruceActive"))
 		return;
 	
 	int owner = FindParentOwnerEntity(entity);
@@ -423,7 +423,7 @@ static void SDKHookCB_FlameManager_TouchPost(int entity, int other)
 
 static Action SDKHookCB_GasManager_Touch(int entity, int other)
 {
-	if (GameRules_GetProp("m_bTruceActive"))
+	if (!g_isEnabled || GameRules_GetProp("m_bTruceActive"))
 		return Plugin_Continue;
 	
 	if (FindParentOwnerEntity(entity) == other)

--- a/addons/sourcemod/scripting/friendlyfire/util.sp
+++ b/addons/sourcemod/scripting/friendlyfire/util.sp
@@ -18,6 +18,11 @@
 #pragma newdecls required
 #pragma semicolon 1
 
+bool IsFriendlyFireEnabled()
+{
+	return g_isEnabled && g_isMapRunning && !GameRules_GetProp("m_bTruceActive");
+}
+
 TFTeam TF2_GetEntityTeam(int entity)
 {
 	return view_as<TFTeam>(GetEntProp(entity, Prop_Data, "m_iTeamNum"));


### PR DESCRIPTION
Entity hooks get removed when `mp_friendlyfire` is disabled, and never re-hooked until it is enabled and the entity re-created. For simplicity, let's just keep hooks always active on entities.

Also fixes #3.