### PR TITLE
Fix sticky launcher secondary attack firing on round end

### DIFF
--- a/addons/sourcemod/scripting/friendlyfire/dhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/dhooks.sp
@@ -656,6 +656,7 @@ static MRESReturn DHookCallback_CTFPipebombLauncher_SecondaryAttack_Pre(int weap
 	int owner = GetEntPropEnt(weapon, Prop_Send, "m_hOwnerEntity");
 	if (owner != -1)
 	{
+		SetActiveRound();
 		Entity(owner).ChangeToSpectator();
 	}
 	
@@ -682,6 +683,7 @@ static MRESReturn DHookCallback_CTFPipebombLauncher_SecondaryAttack_Post(int wea
 	int owner = GetEntPropEnt(weapon, Prop_Send, "m_hOwnerEntity");
 	if (owner != -1)
 	{
+		ResetActiveRound();
 		Entity(owner).ResetTeam();
 	}
 	

--- a/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
@@ -50,7 +50,6 @@ int g_enemyItemIDs[] =
 static ArrayList g_hookData;
 static StringMap g_hookParams_OnTakeDamage;
 static PostThinkType g_postThinkType;
-static RoundState g_roundState;
 
 void SDKHooks_Initialize()
 {
@@ -210,10 +209,8 @@ static void SDKHookCB_Client_PostThink(int client)
 		if (TF2Util_GetWeaponID(activeWeapon) == g_spectatorItemIDs[i])
 		{
 			g_postThinkType = PostThinkType_Spectator;
-			g_roundState = GameRules_GetRoundState();
 			
-			RoundState state = (GameRules_GetProp("m_nGameType") == TF_GAMETYPE_ARENA) ? RoundState_Stalemate : RoundState_RoundRunning;
-			GameRules_SetProp("m_iRoundState", view_as<int>(state));
+			SetActiveRound();
 			Entity(client).ChangeToSpectator();
 		}
 	}
@@ -231,7 +228,7 @@ static void SDKHookCB_Client_PostThinkPost(int client)
 		case PostThinkType_Spectator:
 		{
 			Entity(client).ResetTeam();
-			GameRules_SetProp("m_iRoundState", view_as<int>(g_roundState));
+			ResetActiveRound();
 		}
 		case PostThinkType_EnemyTeam:
 		{

--- a/addons/sourcemod/scripting/friendlyfire/util.sp
+++ b/addons/sourcemod/scripting/friendlyfire/util.sp
@@ -18,6 +18,8 @@
 #pragma newdecls required
 #pragma semicolon 1
 
+static RoundState g_roundState;
+
 bool IsFriendlyFireEnabled()
 {
 	return g_isEnabled && !GameRules_GetProp("m_bTruceActive");
@@ -129,4 +131,16 @@ bool IsWeaponBaseMelee(int entity)
 bool IsProjectileCTFWeaponBaseGrenade(int entity)
 {
 	return HasEntProp(entity, Prop_Data, "CTFWeaponBaseGrenadeProjDetonateThink");
+}
+
+void SetActiveRound()
+{
+	g_roundState = GameRules_GetRoundState();
+	RoundState state = (GameRules_GetProp("m_nGameType") == TF_GAMETYPE_ARENA) ? RoundState_Stalemate : RoundState_RoundRunning;
+	GameRules_SetProp("m_iRoundState", view_as<int>(state));
+}
+
+void ResetActiveRound()
+{
+	GameRules_SetProp("m_iRoundState", view_as<int>(g_roundState));
 }


### PR DESCRIPTION
`CTFPlayer::SecondaryAttack` does not provide actual attack during `RoundState_TeamWin` if client is in spectator team, let's fix that with changing roundstate to active round.