### PR TITLE
Rework hook system

### DIFF
--- a/addons/sourcemod/scripting/friendlyfire.sp
+++ b/addons/sourcemod/scripting/friendlyfire.sp
@@ -150,7 +150,7 @@ public void OnEntityCreated(int entity, const char[] classname)
 		return;
 	
 	DHooks_HookEntity(entity, classname);
-	SDKHooks_HookEntity(entity, classname, true);
+	SDKHooks_HookEntity(entity, classname);
 }
 
 public void OnEntityDestroyed(int entity)
@@ -160,6 +160,8 @@ public void OnEntityDestroyed(int entity)
 	
 	if (!IsValidEntity(entity))
 		return;
+	
+	SDKHooks_UnhookEntity(entity);
 	
 	// If an entity was removed prematurely, reset its owner's team as far back as we need to.
 	// This can happen with projectiles when they collide with the world, not calling the post-hook.

--- a/addons/sourcemod/scripting/friendlyfire.sp
+++ b/addons/sourcemod/scripting/friendlyfire.sp
@@ -193,4 +193,17 @@ void TogglePlugin(bool enable)
 	ConVars_Toggle(enable);
 	DHooks_Toggle(enable);
 	SDKHooks_Toggle(enable);
+	
+	if (enable)
+	{
+		int entity = -1;
+		while ((entity = FindEntityByClassname(entity, "*")) != -1)
+		{
+			char classname[64];
+			if (!GetEntityClassname(entity, classname, sizeof(classname)))
+				continue;
+			
+			OnEntityCreated(entity, classname);
+		}
+	}
 }

--- a/addons/sourcemod/scripting/friendlyfire.sp
+++ b/addons/sourcemod/scripting/friendlyfire.sp
@@ -144,22 +144,13 @@ public void OnPluginEnd()
 	TogglePlugin(false);
 }
 
-public void OnClientPutInServer(int client)
-{
-	if (!g_isEnabled)
-		return;
-	
-	DHooks_OnClientPutInServer(client);
-	SDKHooks_OnClientPutInServer(client);
-}
-
 public void OnEntityCreated(int entity, const char[] classname)
 {
 	if (!g_isEnabled || !g_isMapRunning)
 		return;
 	
-	DHooks_OnEntityCreated(entity, classname);
-	SDKHooks_OnEntityCreated(entity, classname);
+	DHooks_HookEntity(entity, classname);
+	SDKHooks_HookEntity(entity, classname, true);
 }
 
 public void OnEntityDestroyed(int entity)
@@ -199,35 +190,5 @@ void TogglePlugin(bool enable)
 	
 	ConVars_Toggle(enable);
 	DHooks_Toggle(enable);
-	
-	if (enable)
-	{
-		for (int client = 1; client <= MaxClients; client++)
-		{
-			if (!IsClientInGame(client))
-				continue;
-			
-			OnClientPutInServer(client);
-		}
-		
-		int entity = -1;
-		while ((entity = FindEntityByClassname(entity, "*")) != -1)
-		{
-			char classname[64];
-			if (GetEntityClassname(entity, classname, sizeof(classname)))
-			{
-				OnEntityCreated(entity, classname);
-			}
-		}
-	}
-	else
-	{
-		for (int client = 1; client <= MaxClients; client++)
-		{
-			if (!IsClientInGame(client))
-				continue;
-			
-			SDKHooks_UnhookClient(client);
-		}
-	}
+	SDKHooks_Toggle(enable);
 }

--- a/addons/sourcemod/scripting/friendlyfire/data.sp
+++ b/addons/sourcemod/scripting/friendlyfire/data.sp
@@ -50,8 +50,7 @@ methodmap Entity
 			g_entityProperties = new ArrayList(sizeof(EntityProperties));
 		}
 		
-		// Convert it twice to ensure we store it as an entity reference
-		int ref = EntIndexToEntRef(EntRefToEntIndex(entity));
+		int ref = IsValidEdict(entity) ? EntIndexToEntRef(entity) : entity;
 		
 		if (g_entityProperties.FindValue(ref, EntityProperties::ref) == -1)
 		{

--- a/addons/sourcemod/scripting/friendlyfire/dhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/dhooks.sp
@@ -94,32 +94,32 @@ void DHooks_HookEntity(int entity, const char[] classname)
 	if (IsEntityClient(entity))
 	{
 		// Fixes on-death effects (e.g. ragdolls) showing spectator visuals
-		DHooks_InternalHookEntity(g_dhook_CBasePlayer_Event_Killed, Hook_Pre, entity, DHookCallback_CTFPlayer_Event_Killed_Pre);
-		DHooks_InternalHookEntity(g_dhook_CBasePlayer_Event_Killed, Hook_Post, entity, DHookCallback_CTFPlayer_Event_Killed_Post);
+		DHooks_HookEntityInternal(g_dhook_CBasePlayer_Event_Killed, Hook_Pre, entity, DHookCallback_CTFPlayer_Event_Killed_Pre);
+		DHooks_HookEntityInternal(g_dhook_CBasePlayer_Event_Killed, Hook_Post, entity, DHookCallback_CTFPlayer_Event_Killed_Post);
 	}
 	else if (!strncmp(classname, "tf_projectile_", 14))
 	{
 		// Fixes projectiles sometimes not colliding with teammates
-		DHooks_InternalHookEntity(g_dhook_CBaseProjectile_CanCollideWithTeammates, Hook_Post, entity, DHookCallback_CBaseProjectile_CanCollideWithTeammates_Post);
+		DHooks_HookEntityInternal(g_dhook_CBaseProjectile_CanCollideWithTeammates, Hook_Post, entity, DHookCallback_CBaseProjectile_CanCollideWithTeammates_Post);
 		
 		if (IsEntityBaseGrenadeProjectile(entity))
 		{
 			// Fixes grenades rarely bouncing off friendly objects
-			DHooks_InternalHookEntity(g_dhook_CBaseEntity_VPhysicsUpdate, Hook_Pre, entity, DHookCallback_CTFWeaponBaseGrenadeProj_VPhysicsUpdate_Pre);
-			DHooks_InternalHookEntity(g_dhook_CBaseEntity_VPhysicsUpdate, Hook_Post, entity, DHookCallback_CTFWeaponBaseGrenade_VPhysicsUpdate_Post);
+			DHooks_HookEntityInternal(g_dhook_CBaseEntity_VPhysicsUpdate, Hook_Pre, entity, DHookCallback_CTFWeaponBaseGrenadeProj_VPhysicsUpdate_Pre);
+			DHooks_HookEntityInternal(g_dhook_CBaseEntity_VPhysicsUpdate, Hook_Post, entity, DHookCallback_CTFWeaponBaseGrenade_VPhysicsUpdate_Post);
 		}
 		
 		if (!strncmp(classname, "tf_projectile_jar", 17))
 		{
 			// Fixes jars not applying effects to teammates when hitting the world
-			DHooks_InternalHookEntity(g_dhook_CBaseGrenade_Explode, Hook_Pre, entity, DHookCallback_CTFProjectile_Jar_Explode_Pre);
-			DHooks_InternalHookEntity(g_dhook_CBaseGrenade_Explode, Hook_Post, entity, DHookCallback_CTFProjectile_Jar_Explode_Post);
+			DHooks_HookEntityInternal(g_dhook_CBaseGrenade_Explode, Hook_Pre, entity, DHookCallback_CTFProjectile_Jar_Explode_Pre);
+			DHooks_HookEntityInternal(g_dhook_CBaseGrenade_Explode, Hook_Post, entity, DHookCallback_CTFProjectile_Jar_Explode_Post);
 		}
 		else if (StrEqual(classname, "tf_projectile_flare"))
 		{
 			// Fixes Scorch Shot knockback on teammates
-			DHooks_InternalHookEntity(g_dhook_CTFBaseRocket_Explode, Hook_Pre, entity, DHookCallback_CTFProjectile_Flare_Explode_Pre);
-			DHooks_InternalHookEntity(g_dhook_CTFBaseRocket_Explode, Hook_Post, entity, DHookCallback_CTFProjectile_Flare_Explode_Post);
+			DHooks_HookEntityInternal(g_dhook_CTFBaseRocket_Explode, Hook_Pre, entity, DHookCallback_CTFProjectile_Flare_Explode_Pre);
+			DHooks_HookEntityInternal(g_dhook_CTFBaseRocket_Explode, Hook_Post, entity, DHookCallback_CTFProjectile_Flare_Explode_Post);
 		}
 	}
 	else if (TF2Util_IsEntityWeapon(entity))
@@ -127,8 +127,8 @@ void DHooks_HookEntity(int entity, const char[] classname)
 		if (IsEntityBaseMelee(entity))
 		{
 			// Fixes wrenches not being able to upgrade friendly objects, as well as a few other melee weapons
-			DHooks_InternalHookEntity(g_dhook_CTFWeaponBaseMelee_Smack, Hook_Pre, entity, DHookCallback_CTFWeaponBaseMelee_Smack_Pre);
-			DHooks_InternalHookEntity(g_dhook_CTFWeaponBaseMelee_Smack, Hook_Post, entity, DHookCallback_CTFWeaponBaseMelee_Smack_Post);
+			DHooks_HookEntityInternal(g_dhook_CTFWeaponBaseMelee_Smack, Hook_Pre, entity, DHookCallback_CTFWeaponBaseMelee_Smack_Pre);
+			DHooks_HookEntityInternal(g_dhook_CTFWeaponBaseMelee_Smack, Hook_Post, entity, DHookCallback_CTFWeaponBaseMelee_Smack_Post);
 		}
 		else
 		{
@@ -136,13 +136,13 @@ void DHooks_HookEntity(int entity, const char[] classname)
 			if (weaponID == TF_WEAPON_SNIPERRIFLE || weaponID == TF_WEAPON_SNIPERRIFLE_DECAP || weaponID == TF_WEAPON_SNIPERRIFLE_CLASSIC)
 			{
 				// Fixes Sniper Rifles dealing no damage to teammates
-				DHooks_InternalHookEntity(g_dhook_CTFSniperRifle_GetCustomDamageType, Hook_Post, entity, DHookCallback_CTFSniperRifle_GetCustomDamageType_Post);
+				DHooks_HookEntityInternal(g_dhook_CTFSniperRifle_GetCustomDamageType, Hook_Post, entity, DHookCallback_CTFSniperRifle_GetCustomDamageType_Post);
 			}
 			else if (weaponID == TF_WEAPON_PIPEBOMBLAUNCHER)
 			{
 				// Fixes pipebomb launchers not being able to knock around friendly pipebombs
-				DHooks_InternalHookEntity(g_dhook_CTFWeaponBase_SecondaryAttack, Hook_Pre, entity, DHookCallback_CTFPipebombLauncher_SecondaryAttack_Pre);
-				DHooks_InternalHookEntity(g_dhook_CTFWeaponBase_SecondaryAttack, Hook_Post, entity, DHookCallback_CTFPipebombLauncher_SecondaryAttack_Post);
+				DHooks_HookEntityInternal(g_dhook_CTFWeaponBase_SecondaryAttack, Hook_Pre, entity, DHookCallback_CTFPipebombLauncher_SecondaryAttack_Pre);
+				DHooks_HookEntityInternal(g_dhook_CTFWeaponBase_SecondaryAttack, Hook_Post, entity, DHookCallback_CTFPipebombLauncher_SecondaryAttack_Post);
 			}
 		}
 	}
@@ -176,7 +176,7 @@ static DynamicHook DHooks_AddDynamicHook(GameData gamedata, const char[] name)
 	return hook;
 }
 
-static void DHooks_InternalHookEntity(DynamicHook hook, HookMode mode, int entity, DHookCallback callback)
+static void DHooks_HookEntityInternal(DynamicHook hook, HookMode mode, int entity, DHookCallback callback)
 {
 	if (!hook)
 		return;

--- a/addons/sourcemod/scripting/friendlyfire/dhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/dhooks.sp
@@ -242,7 +242,7 @@ public void DHookRemovalCB_OnHookRemoved(int hookid)
 
 static MRESReturn DHookCallback_CTFPlayer_Event_Killed_Pre(int player, DHookParam params)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	// Switch back to the original team to force proper skin for ragdolls and other on-death effects
@@ -253,7 +253,7 @@ static MRESReturn DHookCallback_CTFPlayer_Event_Killed_Pre(int player, DHookPara
 
 static MRESReturn DHookCallback_CTFPlayer_Event_Killed_Post(int player, DHookParam params)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	Entity(player).ResetTeam();
@@ -263,7 +263,7 @@ static MRESReturn DHookCallback_CTFPlayer_Event_Killed_Post(int player, DHookPar
 
 static MRESReturn DHookCallback_CTFProjectile_Jar_Explode_Pre(int entity, DHookParam params)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	int thrower = GetEntPropEnt(entity, Prop_Send, "m_hThrower");
@@ -278,7 +278,7 @@ static MRESReturn DHookCallback_CTFProjectile_Jar_Explode_Pre(int entity, DHookP
 
 static MRESReturn DHookCallback_CTFProjectile_Jar_Explode_Post(int entity, DHookParam params)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	int thrower = GetEntPropEnt(entity, Prop_Send, "m_hThrower");
@@ -293,7 +293,7 @@ static MRESReturn DHookCallback_CTFProjectile_Jar_Explode_Post(int entity, DHook
 
 static MRESReturn DHookCallback_CTFProjectile_Flare_Explode_Pre(int entity, DHookParam params)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	int other = params.Get(2);
@@ -305,7 +305,7 @@ static MRESReturn DHookCallback_CTFProjectile_Flare_Explode_Pre(int entity, DHoo
 
 static MRESReturn DHookCallback_CTFProjectile_Flare_Explode_Post(int entity, DHookParam params)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	int other = params.Get(2);
@@ -317,7 +317,7 @@ static MRESReturn DHookCallback_CTFProjectile_Flare_Explode_Post(int entity, DHo
 
 static MRESReturn DHookCallback_CBaseProjectile_CanCollideWithTeammates_Post(int entity, DHookReturn ret)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	// Always make projectiles collide with teammates
@@ -328,7 +328,7 @@ static MRESReturn DHookCallback_CBaseProjectile_CanCollideWithTeammates_Post(int
 
 static MRESReturn DHookCallback_CTFSniperRifle_GetCustomDamageType_Post(int entity, DHookReturn ret)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	// Allows Sniper Rifles to hit teammates, without breaking Machina penetration
@@ -344,7 +344,7 @@ static MRESReturn DHookCallback_CTFSniperRifle_GetCustomDamageType_Post(int enti
 
 static MRESReturn DHookCallback_CTFWeaponBaseMelee_Smack_Pre(int entity)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	int owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
@@ -371,7 +371,7 @@ static MRESReturn DHookCallback_CTFWeaponBaseMelee_Smack_Pre(int entity)
 
 static MRESReturn DHookCallback_CTFWeaponBaseMelee_Smack_Post(int entity)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	int owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
@@ -397,7 +397,7 @@ static MRESReturn DHookCallback_CTFWeaponBaseMelee_Smack_Post(int entity)
 
 static MRESReturn DHookCallback_CBaseEntity_InSameTeam_Pre(int entity, DHookReturn ret, DHookParam params)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	char classname[64];
@@ -433,7 +433,7 @@ static MRESReturn DHookCallback_CBaseEntity_InSameTeam_Pre(int entity, DHookRetu
 
 static MRESReturn DHookCallback_CBaseEntity_PhysicsDispatchThink_Pre(int entity)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	char classname[64];
@@ -543,7 +543,7 @@ static MRESReturn DHookCallback_CBaseEntity_PhysicsDispatchThink_Pre(int entity)
 
 static MRESReturn DHookCallback_CBaseEntity_PhysicsDispatchThink_Post(int entity)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	switch (g_thinkFunction)
@@ -622,7 +622,7 @@ static MRESReturn DHookCallback_CBaseEntity_PhysicsDispatchThink_Post(int entity
 
 static MRESReturn DHookCallback_CWeaponMedigun_AllowedToHealTarget_Pre(int medigun, DHookReturn ret, DHookParam params)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	// Temporarily remove our CBaseEntity::InSameTeam detour to allow healing teammates
@@ -634,7 +634,7 @@ static MRESReturn DHookCallback_CWeaponMedigun_AllowedToHealTarget_Pre(int medig
 
 static MRESReturn DHookCallback_CWeaponMedigun_AllowedToHealTarget_Post(int medigun, DHookReturn ret, DHookParam params)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	if (sm_friendlyfire_medic_allow_healing.BoolValue)
@@ -645,7 +645,7 @@ static MRESReturn DHookCallback_CWeaponMedigun_AllowedToHealTarget_Post(int medi
 
 static MRESReturn DHookCallback_CTFPipebombLauncher_SecondaryAttack_Pre(int weapon)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	// Switch the weapon
@@ -674,7 +674,7 @@ static MRESReturn DHookCallback_CTFPipebombLauncher_SecondaryAttack_Pre(int weap
 
 static MRESReturn DHookCallback_CTFPipebombLauncher_SecondaryAttack_Post(int weapon)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	Entity(weapon).ResetTeam();
@@ -700,7 +700,7 @@ static MRESReturn DHookCallback_CTFPipebombLauncher_SecondaryAttack_Post(int wea
 
 static MRESReturn DHookCallback_CTFWeaponBaseGrenadeProj_VPhysicsUpdate_Pre(int entity, DHookParam params)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	int thrower = GetEntPropEnt(entity, Prop_Send, "m_hThrower");
@@ -730,7 +730,7 @@ static MRESReturn DHookCallback_CTFWeaponBaseGrenadeProj_VPhysicsUpdate_Pre(int 
 
 static MRESReturn DHookCallback_CTFWeaponBaseGrenade_VPhysicsUpdate_Post(int entity, DHookParam params)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return MRES_Ignored;
 	
 	int thrower = GetEntPropEnt(entity, Prop_Send, "m_hThrower");

--- a/addons/sourcemod/scripting/friendlyfire/dhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/dhooks.sp
@@ -84,7 +84,8 @@ void DHooks_Toggle(bool enable)
 		for (int i = g_dynamicHookIds.Length - 1; i >= 0; i--)
 		{
 			int hookid = g_dynamicHookIds.Get(i);
-			DynamicHook.RemoveHook(hookid);
+			if (!DynamicHook.RemoveHook(hookid))
+				LogError("Failed to remove dynamic hook (ID %d)", hookid);
 		}
 	}
 }
@@ -209,35 +210,25 @@ static void DHooks_ToggleDetour(DetourData data, bool enable)
 	if (data.callbackPre != INVALID_FUNCTION)
 	{
 		if (enable)
-		{
 			data.detour.Enable(Hook_Pre, data.callbackPre);
-		}
 		else
-		{
 			data.detour.Disable(Hook_Pre, data.callbackPre);
-		}
 	}
 	
 	if (data.callbackPost != INVALID_FUNCTION)
 	{
 		if (enable)
-		{
 			data.detour.Enable(Hook_Post, data.callbackPost);
-		}
 		else
-		{
 			data.detour.Disable(Hook_Post, data.callbackPost);
-		}
 	}
 }
 
-public void DHookRemovalCB_OnHookRemoved(int hookid)
+static void DHookRemovalCB_OnHookRemoved(int hookid)
 {
 	int index = g_dynamicHookIds.FindValue(hookid);
 	if (index != -1)
-	{
 		g_dynamicHookIds.Erase(index);
-	}
 }
 
 static MRESReturn DHookCallback_CTFPlayer_Event_Killed_Pre(int player, DHookParam params)

--- a/addons/sourcemod/scripting/friendlyfire/dhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/dhooks.sp
@@ -102,6 +102,13 @@ void DHooks_HookEntity(int entity, const char[] classname)
 		// Fixes projectiles sometimes not colliding with teammates
 		DHooks_InternalHookEntity(g_dhook_CBaseProjectile_CanCollideWithTeammates, Hook_Post, entity, DHookCallback_CBaseProjectile_CanCollideWithTeammates_Post);
 		
+		if (IsEntityBaseGrenadeProjectile(entity))
+		{
+			// Fixes grenades rarely bouncing off friendly objects
+			DHooks_InternalHookEntity(g_dhook_CBaseEntity_VPhysicsUpdate, Hook_Pre, entity, DHookCallback_CTFWeaponBaseGrenadeProj_VPhysicsUpdate_Pre);
+			DHooks_InternalHookEntity(g_dhook_CBaseEntity_VPhysicsUpdate, Hook_Post, entity, DHookCallback_CTFWeaponBaseGrenade_VPhysicsUpdate_Post);
+		}
+		
 		if (!strncmp(classname, "tf_projectile_jar", 17))
 		{
 			// Fixes jars not applying effects to teammates when hitting the world
@@ -114,26 +121,18 @@ void DHooks_HookEntity(int entity, const char[] classname)
 			DHooks_InternalHookEntity(g_dhook_CTFBaseRocket_Explode, Hook_Pre, entity, DHookCallback_CTFProjectile_Flare_Explode_Pre);
 			DHooks_InternalHookEntity(g_dhook_CTFBaseRocket_Explode, Hook_Post, entity, DHookCallback_CTFProjectile_Flare_Explode_Post);
 		}
-		else if (IsProjectileCTFWeaponBaseGrenade(entity))
-		{
-			// Fixes grenades rarely bouncing off friendly objects
-			DHooks_InternalHookEntity(g_dhook_CBaseEntity_VPhysicsUpdate, Hook_Pre, entity, DHookCallback_CTFWeaponBaseGrenade_VPhysicsUpdate_Pre);
-			DHooks_InternalHookEntity(g_dhook_CBaseEntity_VPhysicsUpdate, Hook_Post, entity, DHookCallback_CTFWeaponBaseGrenade_VPhysicsUpdate_Post);
-		}
 	}
-	
-	if (TF2Util_IsEntityWeapon(entity))
+	else if (TF2Util_IsEntityWeapon(entity))
 	{
-		if (IsWeaponBaseMelee(entity))
+		if (IsEntityBaseMelee(entity))
 		{
-			// Fixes wrenches not being able to upgrade friendly objects and a few other melee weapons
+			// Fixes wrenches not being able to upgrade friendly objects, as well as a few other melee weapons
 			DHooks_InternalHookEntity(g_dhook_CTFWeaponBaseMelee_Smack, Hook_Pre, entity, DHookCallback_CTFWeaponBaseMelee_Smack_Pre);
 			DHooks_InternalHookEntity(g_dhook_CTFWeaponBaseMelee_Smack, Hook_Post, entity, DHookCallback_CTFWeaponBaseMelee_Smack_Post);
 		}
 		else
 		{
 			int weaponID = TF2Util_GetWeaponID(entity);
-			
 			if (weaponID == TF_WEAPON_SNIPERRIFLE || weaponID == TF_WEAPON_SNIPERRIFLE_DECAP || weaponID == TF_WEAPON_SNIPERRIFLE_CLASSIC)
 			{
 				// Fixes Sniper Rifles dealing no damage to teammates
@@ -417,7 +416,7 @@ static MRESReturn DHookCallback_CBaseEntity_InSameTeam_Pre(int entity, DHookRetu
 	// Allow Rescue Ranger healing bolts to work on friendly buildings
 	if (StrEqual(classname, "tf_projectile_arrow") &&
 		GetEntProp(entity, Prop_Send, "m_iProjectileType") == TF_PROJECTILE_BUILDING_REPAIR_BOLT &&
-		IsBaseObject(other) &&
+		IsEntityBaseObject(other) &&
 		IsObjectFriendly(other, GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity")))
 	{
 		ret.Value = true;
@@ -699,7 +698,7 @@ static MRESReturn DHookCallback_CTFPipebombLauncher_SecondaryAttack_Post(int wea
 	return MRES_Ignored;
 }
 
-static MRESReturn DHookCallback_CTFWeaponBaseGrenade_VPhysicsUpdate_Pre(int entity, DHookParam params)
+static MRESReturn DHookCallback_CTFWeaponBaseGrenadeProj_VPhysicsUpdate_Pre(int entity, DHookParam params)
 {
 	if (!IsFriendlyFireEnabled())
 		return MRES_Ignored;

--- a/addons/sourcemod/scripting/friendlyfire/dhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/dhooks.sp
@@ -242,7 +242,7 @@ public void DHookRemovalCB_OnHookRemoved(int hookid)
 
 static MRESReturn DHookCallback_CTFPlayer_Event_Killed_Pre(int player, DHookParam params)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	// Switch back to the original team to force proper skin for ragdolls and other on-death effects
@@ -253,7 +253,7 @@ static MRESReturn DHookCallback_CTFPlayer_Event_Killed_Pre(int player, DHookPara
 
 static MRESReturn DHookCallback_CTFPlayer_Event_Killed_Post(int player, DHookParam params)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	Entity(player).ResetTeam();
@@ -263,7 +263,7 @@ static MRESReturn DHookCallback_CTFPlayer_Event_Killed_Post(int player, DHookPar
 
 static MRESReturn DHookCallback_CTFProjectile_Jar_Explode_Pre(int entity, DHookParam params)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	int thrower = GetEntPropEnt(entity, Prop_Send, "m_hThrower");
@@ -278,7 +278,7 @@ static MRESReturn DHookCallback_CTFProjectile_Jar_Explode_Pre(int entity, DHookP
 
 static MRESReturn DHookCallback_CTFProjectile_Jar_Explode_Post(int entity, DHookParam params)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	int thrower = GetEntPropEnt(entity, Prop_Send, "m_hThrower");
@@ -293,7 +293,7 @@ static MRESReturn DHookCallback_CTFProjectile_Jar_Explode_Post(int entity, DHook
 
 static MRESReturn DHookCallback_CTFProjectile_Flare_Explode_Pre(int entity, DHookParam params)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	int other = params.Get(2);
@@ -305,7 +305,7 @@ static MRESReturn DHookCallback_CTFProjectile_Flare_Explode_Pre(int entity, DHoo
 
 static MRESReturn DHookCallback_CTFProjectile_Flare_Explode_Post(int entity, DHookParam params)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	int other = params.Get(2);
@@ -317,7 +317,7 @@ static MRESReturn DHookCallback_CTFProjectile_Flare_Explode_Post(int entity, DHo
 
 static MRESReturn DHookCallback_CBaseProjectile_CanCollideWithTeammates_Post(int entity, DHookReturn ret)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	// Always make projectiles collide with teammates
@@ -328,7 +328,7 @@ static MRESReturn DHookCallback_CBaseProjectile_CanCollideWithTeammates_Post(int
 
 static MRESReturn DHookCallback_CTFSniperRifle_GetCustomDamageType_Post(int entity, DHookReturn ret)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	// Allows Sniper Rifles to hit teammates, without breaking Machina penetration
@@ -344,7 +344,7 @@ static MRESReturn DHookCallback_CTFSniperRifle_GetCustomDamageType_Post(int enti
 
 static MRESReturn DHookCallback_CTFWeaponBaseMelee_Smack_Pre(int entity)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	int owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
@@ -371,7 +371,7 @@ static MRESReturn DHookCallback_CTFWeaponBaseMelee_Smack_Pre(int entity)
 
 static MRESReturn DHookCallback_CTFWeaponBaseMelee_Smack_Post(int entity)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	int owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
@@ -397,7 +397,7 @@ static MRESReturn DHookCallback_CTFWeaponBaseMelee_Smack_Post(int entity)
 
 static MRESReturn DHookCallback_CBaseEntity_InSameTeam_Pre(int entity, DHookReturn ret, DHookParam params)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	char classname[64];
@@ -433,7 +433,7 @@ static MRESReturn DHookCallback_CBaseEntity_InSameTeam_Pre(int entity, DHookRetu
 
 static MRESReturn DHookCallback_CBaseEntity_PhysicsDispatchThink_Pre(int entity)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	char classname[64];
@@ -543,7 +543,7 @@ static MRESReturn DHookCallback_CBaseEntity_PhysicsDispatchThink_Pre(int entity)
 
 static MRESReturn DHookCallback_CBaseEntity_PhysicsDispatchThink_Post(int entity)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	switch (g_thinkFunction)
@@ -622,7 +622,7 @@ static MRESReturn DHookCallback_CBaseEntity_PhysicsDispatchThink_Post(int entity
 
 static MRESReturn DHookCallback_CWeaponMedigun_AllowedToHealTarget_Pre(int medigun, DHookReturn ret, DHookParam params)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	// Temporarily remove our CBaseEntity::InSameTeam detour to allow healing teammates
@@ -634,7 +634,7 @@ static MRESReturn DHookCallback_CWeaponMedigun_AllowedToHealTarget_Pre(int medig
 
 static MRESReturn DHookCallback_CWeaponMedigun_AllowedToHealTarget_Post(int medigun, DHookReturn ret, DHookParam params)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	if (sm_friendlyfire_medic_allow_healing.BoolValue)
@@ -645,7 +645,7 @@ static MRESReturn DHookCallback_CWeaponMedigun_AllowedToHealTarget_Post(int medi
 
 static MRESReturn DHookCallback_CTFPipebombLauncher_SecondaryAttack_Pre(int weapon)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	// Switch the weapon
@@ -674,7 +674,7 @@ static MRESReturn DHookCallback_CTFPipebombLauncher_SecondaryAttack_Pre(int weap
 
 static MRESReturn DHookCallback_CTFPipebombLauncher_SecondaryAttack_Post(int weapon)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	Entity(weapon).ResetTeam();
@@ -700,7 +700,7 @@ static MRESReturn DHookCallback_CTFPipebombLauncher_SecondaryAttack_Post(int wea
 
 static MRESReturn DHookCallback_CTFWeaponBaseGrenadeProj_VPhysicsUpdate_Pre(int entity, DHookParam params)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	int thrower = GetEntPropEnt(entity, Prop_Send, "m_hThrower");
@@ -730,7 +730,7 @@ static MRESReturn DHookCallback_CTFWeaponBaseGrenadeProj_VPhysicsUpdate_Pre(int 
 
 static MRESReturn DHookCallback_CTFWeaponBaseGrenade_VPhysicsUpdate_Post(int entity, DHookParam params)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return MRES_Ignored;
 	
 	int thrower = GetEntPropEnt(entity, Prop_Send, "m_hThrower");

--- a/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
@@ -174,7 +174,7 @@ static void SDKHooks_HookEntityInternal(int entity, SDKHookType type, SDKHookCB 
 // CTFPlayerShared::OnPreDataChanged
 static void SDKHookCB_Client_PreThink(int client)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return;
 	
 	// Disable radius buffs like Buff Banner or King Rune
@@ -184,7 +184,7 @@ static void SDKHookCB_Client_PreThink(int client)
 // CTFPlayerShared::OnPreDataChanged
 static void SDKHookCB_Client_PreThinkPost(int client)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return;
 	
 	Entity(client).ResetTeam();
@@ -193,7 +193,7 @@ static void SDKHookCB_Client_PreThinkPost(int client)
 // CTFWeaponBase::ItemPostFrame
 static void SDKHookCB_Client_PostThink(int client)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return;
 	
 	// CTFPlayer::DoTauntAttack
@@ -249,7 +249,7 @@ static void SDKHookCB_Client_PostThink(int client)
 // CTFWeaponBase::ItemPostFrame
 static void SDKHookCB_Client_PostThinkPost(int client)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return;
 	
 	// Change everything back to how it was accordingly
@@ -277,7 +277,7 @@ static void SDKHookCB_Client_PostThinkPost(int client)
 
 static Action SDKHookCB_Client_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return Plugin_Continue;
 	
 	// Attacker and victim are commonly modified by other plugins, store them off
@@ -299,7 +299,7 @@ static Action SDKHookCB_Client_OnTakeDamage(int victim, int &attacker, int &infl
 
 static void SDKHookCB_Client_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return;
 	
 	g_hookParams_OnTakeDamage.GetValue("victim", victim);
@@ -317,7 +317,7 @@ static void SDKHookCB_Client_OnTakeDamagePost(int victim, int attacker, int infl
 
 static Action SDKHookCB_Client_SetTransmit(int entity, int client)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return Plugin_Continue;
 	
 	// Don't transmit invisible spies to living players
@@ -332,7 +332,7 @@ static Action SDKHookCB_Client_SetTransmit(int entity, int client)
 
 static Action SDKHookCB_ObjectDispenser_StartTouch(int entity, int other)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return Plugin_Continue;
 	
 	if (IsEntityClient(other) && !IsObjectFriendly(entity, other))
@@ -345,7 +345,7 @@ static Action SDKHookCB_ObjectDispenser_StartTouch(int entity, int other)
 
 static void SDKHookCB_ObjectDispenser_StartTouchPost(int entity, int other)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return;
 	
 	if (IsEntityClient(other) && !IsObjectFriendly(entity, other))
@@ -356,7 +356,7 @@ static void SDKHookCB_ObjectDispenser_StartTouchPost(int entity, int other)
 
 static void SDKHookCB_Object_SpawnPost(int entity)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return;
 	
 	// Enable collisions for both teams
@@ -366,7 +366,7 @@ static void SDKHookCB_Object_SpawnPost(int entity)
 
 static Action SDKHookCB_Projectile_Touch(int entity, int other)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return Plugin_Continue;
 	
 	if (other == 0)
@@ -384,7 +384,7 @@ static Action SDKHookCB_Projectile_Touch(int entity, int other)
 
 static void SDKHookCB_Projectile_TouchPost(int entity, int other)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return;
 	
 	if (other == 0)
@@ -400,7 +400,7 @@ static void SDKHookCB_Projectile_TouchPost(int entity, int other)
 
 static Action SDKHookCB_ProjectilePipeRemote_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return Plugin_Continue;
 	
 	if (attacker != -1)
@@ -418,7 +418,7 @@ static Action SDKHookCB_ProjectilePipeRemote_OnTakeDamage(int victim, int &attac
 
 static void SDKHookCB_ProjectilePipeRemote_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return;
 	
 	if (attacker != -1)
@@ -432,7 +432,7 @@ static void SDKHookCB_ProjectilePipeRemote_OnTakeDamagePost(int victim, int atta
 
 static Action SDKHookCB_FlameManager_Touch(int entity, int other)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return Plugin_Continue;
 	
 	int owner = FindParentOwnerEntity(entity);
@@ -447,7 +447,7 @@ static Action SDKHookCB_FlameManager_Touch(int entity, int other)
 
 static void SDKHookCB_FlameManager_TouchPost(int entity, int other)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return;
 	
 	int owner = FindParentOwnerEntity(entity);
@@ -459,7 +459,7 @@ static void SDKHookCB_FlameManager_TouchPost(int entity, int other)
 
 static Action SDKHookCB_GasManager_Touch(int entity, int other)
 {
-	if (!IsFriendlyFireEnabled())
+	if (!IsTruceActive())
 		return Plugin_Continue;
 	
 	if (FindParentOwnerEntity(entity) == other)

--- a/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
@@ -90,53 +90,56 @@ void SDKHooks_HookEntity(int entity, const char[] classname)
 {
 	if (IsEntityClient(entity))
 	{
-		SDKHooks_InternalHookEntity(entity, SDKHook_PreThink, SDKHookCB_Client_PreThink);
-		SDKHooks_InternalHookEntity(entity, SDKHook_PreThinkPost, SDKHookCB_Client_PreThinkPost);
-		SDKHooks_InternalHookEntity(entity, SDKHook_PostThink, SDKHookCB_Client_PostThink);
-		SDKHooks_InternalHookEntity(entity, SDKHook_PostThinkPost, SDKHookCB_Client_PostThinkPost);
-		SDKHooks_InternalHookEntity(entity, SDKHook_OnTakeDamage, SDKHookCB_Client_OnTakeDamage);
-		SDKHooks_InternalHookEntity(entity, SDKHook_OnTakeDamagePost, SDKHookCB_Client_OnTakeDamagePost);
-		SDKHooks_InternalHookEntity(entity, SDKHook_SetTransmit, SDKHookCB_Client_SetTransmit);
+		// Fixes various weapons and items in friendly fire
+		SDKHooks_HookEntityInternal(entity, SDKHook_PreThink, SDKHookCB_Client_PreThink);
+		SDKHooks_HookEntityInternal(entity, SDKHook_PreThinkPost, SDKHookCB_Client_PreThinkPost);
+		SDKHooks_HookEntityInternal(entity, SDKHook_PostThink, SDKHookCB_Client_PostThink);
+		SDKHooks_HookEntityInternal(entity, SDKHook_PostThinkPost, SDKHookCB_Client_PostThinkPost);
+		SDKHooks_HookEntityInternal(entity, SDKHook_OnTakeDamage, SDKHookCB_Client_OnTakeDamage);
+		SDKHooks_HookEntityInternal(entity, SDKHook_OnTakeDamagePost, SDKHookCB_Client_OnTakeDamagePost);
+		
+		// Makes cloaked spies fully invisible
+		SDKHooks_HookEntityInternal(entity, SDKHook_SetTransmit, SDKHookCB_Client_SetTransmit);
 	}
 	else
 	{
-		// Makes objects solid to teammates
 		if (!strncmp(classname, "obj_", 4))
 		{
-			SDKHooks_InternalHookEntity(entity, SDKHook_SpawnPost, SDKHookCB_Object_SpawnPost);
+			// Makes objects solid to teammates
+			SDKHooks_HookEntityInternal(entity, SDKHook_SpawnPost, SDKHookCB_Object_SpawnPost);
 		}
 		
-		// Prevents Dispensers from healing teammates
 		if (StrEqual(classname, "obj_dispenser") || StrEqual(classname, "pd_dispenser"))
 		{
-			SDKHooks_InternalHookEntity(entity, SDKHook_StartTouch, SDKHookCB_ObjectDispenser_StartTouch);
-			SDKHooks_InternalHookEntity(entity, SDKHook_StartTouchPost, SDKHookCB_ObjectDispenser_StartTouchPost);
+			// Prevents Dispensers from healing teammates
+			SDKHooks_HookEntityInternal(entity, SDKHook_StartTouch, SDKHookCB_ObjectDispenser_StartTouch);
+			SDKHooks_HookEntityInternal(entity, SDKHook_StartTouchPost, SDKHookCB_ObjectDispenser_StartTouchPost);
 		}
 		else if (!strncmp(classname, "tf_projectile_", 14))
 		{
 			if (StrEqual(classname, "tf_projectile_cleaver") || StrEqual(classname, "tf_projectile_pipe"))
 			{
 				// Fixes the cleaver and pipes dealing no damage to certain entities
-				SDKHooks_InternalHookEntity(entity, SDKHook_Touch, SDKHookCB_Projectile_Touch);
-				SDKHooks_InternalHookEntity(entity, SDKHook_TouchPost, SDKHookCB_Projectile_TouchPost);
+				SDKHooks_HookEntityInternal(entity, SDKHook_Touch, SDKHookCB_Projectile_Touch);
+				SDKHooks_HookEntityInternal(entity, SDKHook_TouchPost, SDKHookCB_Projectile_TouchPost);
 			}
 			else if (StrEqual(classname, "tf_projectile_pipe_remote"))
 			{
 				// Allows detonating teammate's pipebombs
-				SDKHooks_InternalHookEntity(entity, SDKHook_OnTakeDamage, SDKHookCB_ProjectilePipeRemote_OnTakeDamage);
-				SDKHooks_InternalHookEntity(entity, SDKHook_OnTakeDamagePost, SDKHookCB_ProjectilePipeRemote_OnTakeDamagePost);
+				SDKHooks_HookEntityInternal(entity, SDKHook_OnTakeDamage, SDKHookCB_ProjectilePipeRemote_OnTakeDamage);
+				SDKHooks_HookEntityInternal(entity, SDKHook_OnTakeDamagePost, SDKHookCB_ProjectilePipeRemote_OnTakeDamagePost);
 			}
 		}
 		else if (StrEqual(classname, "tf_flame_manager"))
 		{
 			// Fixes Flame Throwers dealing no damage to teammates
-			SDKHooks_InternalHookEntity(entity, SDKHook_Touch, SDKHookCB_FlameManager_Touch);
-			SDKHooks_InternalHookEntity(entity, SDKHook_TouchPost, SDKHookCB_FlameManager_TouchPost);
+			SDKHooks_HookEntityInternal(entity, SDKHook_Touch, SDKHookCB_FlameManager_Touch);
+			SDKHooks_HookEntityInternal(entity, SDKHook_TouchPost, SDKHookCB_FlameManager_TouchPost);
 		}
 		else if (StrEqual(classname, "tf_gas_manager"))
 		{
 			// Prevents Gas Passer clouds from coating the thrower
-			SDKHooks_InternalHookEntity(entity, SDKHook_Touch, SDKHookCB_GasManager_Touch);
+			SDKHooks_HookEntityInternal(entity, SDKHook_Touch, SDKHookCB_GasManager_Touch);
 		}
 	}
 }
@@ -160,7 +163,7 @@ void SDKHooks_UnhookEntity(int entity)
 	}
 }
 
-static void SDKHooks_InternalHookEntity(int entity, SDKHookType type, SDKHookCB callback)
+static void SDKHooks_HookEntityInternal(int entity, SDKHookType type, SDKHookCB callback)
 {
 	SDKHookData data;
 	data.ref = IsValidEdict(entity) ? EntIndexToEntRef(entity) : entity;

--- a/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
@@ -148,17 +148,13 @@ void SDKHooks_UnhookEntity(int entity)
 {
 	int ref = IsValidEdict(entity) ? EntIndexToEntRef(entity) : entity;
 	
-	int index = g_hookData.FindValue(ref, SDKHookData::ref);
-	if (index == -1)
-		return;
-	
 	for (int i = g_hookData.Length - 1; i >= 0; i--)
 	{
 		SDKHookData data;
 		if (g_hookData.GetArray(i, data) && ref == data.ref)
 		{
 			SDKUnhook(data.ref, data.type, data.callback);
-			g_hookData.Erase(index);
+			g_hookData.Erase(i);
 		}
 	}
 }

--- a/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
@@ -60,19 +60,7 @@ void SDKHooks_Initialize()
 
 void SDKHooks_Toggle(bool enable)
 {
-	if (enable)
-	{
-		int entity = -1;
-		while ((entity = FindEntityByClassname(entity, "*")) != -1)
-		{
-			char classname[64];
-			if (!GetEntityClassname(entity, classname, sizeof(classname)))
-				continue;
-			
-			SDKHooks_HookEntity(entity, classname);
-		}
-	}
-	else
+	if (!enable)
 	{
 		for (int i = g_hookData.Length - 1; i >= 0; i--)
 		{

--- a/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
@@ -57,7 +57,6 @@ void SDKHooks_Initialize()
 	g_hookData = new ArrayList(sizeof(SDKHookData));
 	g_hookParams_OnTakeDamage = new StringMap();
 	
-	// Various fixes for player items
 	SDKHooks_AddHook("player", SDKHook_PreThink, SDKHookCB_Client_PreThink);
 	SDKHooks_AddHook("player", SDKHook_PreThinkPost, SDKHookCB_Client_PreThinkPost);
 	SDKHooks_AddHook("player", SDKHook_PostThink, SDKHookCB_Client_PostThink);
@@ -66,8 +65,9 @@ void SDKHooks_Initialize()
 	SDKHooks_AddHook("player", SDKHook_OnTakeDamagePost, SDKHookCB_Client_OnTakeDamagePost);
 	SDKHooks_AddHook("player", SDKHook_SetTransmit, SDKHookCB_Client_SetTransmit);
 	
-	// Makes objects solid to teammates
-	SDKHooks_AddHook("obj_*", SDKHook_SpawnPost, SDKHookCB_Object_SpawnPost);
+	// Makes Engineer buildings solid to teammates
+	SDKHooks_AddHook("obj_dispenser", SDKHook_SpawnPost, SDKHookCB_Object_SpawnPost);
+	SDKHooks_AddHook("obj_sentrygun", SDKHook_SpawnPost, SDKHookCB_Object_SpawnPost);
 	
 	// Prevents Dispensers from healing teammates
 	SDKHooks_AddHook("obj_dispenser", SDKHook_StartTouch, SDKHookCB_ObjectDispenser_StartTouch);
@@ -106,19 +106,14 @@ void SDKHooks_Toggle(bool enable)
 
 void SDKHooks_HookEntity(int entity, const char[] classname, bool hook)
 {
-	for (int i = 0; i < g_hookData.Length; i++)
+	int index = g_hookData.FindString(classname, SDKHookData::classname);
+	if (index == -1)
+		return;
+	
+	for (int i = index; i < g_hookData.Length; i++)
 	{
 		SDKHookData data;
-		if (!g_hookData.GetArray(i, data))
-			continue;
-		
-		int index = StrContains(data.classname, "*");
-		if (index != -1)
-		{
-			data.classname[index] = EOS;
-		}
-		
-		if (index != -1 && !strncmp(classname, data.classname, index) || StrEqual(data.classname, classname))
+		if (g_hookData.GetArray(i, data) && StrEqual(data.classname, classname))
 		{
 			if (hook)
 			{

--- a/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
@@ -20,6 +20,7 @@
 
 enum struct SDKHookData
 {
+	char classname[64];
 	SDKHookType type;
 	SDKHookCB callback;
 }
@@ -56,85 +57,85 @@ void SDKHooks_Initialize()
 	g_hookData = new ArrayList(sizeof(SDKHookData));
 	g_hookParams_OnTakeDamage = new StringMap();
 	
-	SDKHooks_AddHook(SDKHook_PreThink, SDKHookCB_Client_PreThink);
-	SDKHooks_AddHook(SDKHook_PreThinkPost, SDKHookCB_Client_PreThinkPost);
-	SDKHooks_AddHook(SDKHook_PostThink, SDKHookCB_Client_PostThink);
-	SDKHooks_AddHook(SDKHook_PostThinkPost, SDKHookCB_Client_PostThinkPost);
-	SDKHooks_AddHook(SDKHook_OnTakeDamage, SDKHookCB_Client_OnTakeDamage);
-	SDKHooks_AddHook(SDKHook_OnTakeDamagePost, SDKHookCB_Client_OnTakeDamagePost);
-	SDKHooks_AddHook(SDKHook_SetTransmit, SDKHookCB_Client_SetTransmit);
-}
-
-void SDKHooks_OnClientPutInServer(int client)
-{
-	for (int i = 0; i < g_hookData.Length; i++)
-	{
-		SDKHookData data;
-		if (g_hookData.GetArray(i, data))
-		{
-			SDKHook(client, data.type, data.callback);
-		}
-	}
-}
-
-void SDKHooks_UnhookClient(int client)
-{
-	for (int i = 0; i < g_hookData.Length; i++)
-	{
-		SDKHookData data;
-		if (g_hookData.GetArray(i, data))
-		{
-			SDKUnhook(client, data.type, data.callback);
-		}
-	}
-}
-
-void SDKHooks_OnEntityCreated(int entity, const char[] classname)
-{
+	// Various fixes for player items
+	SDKHooks_AddHook("player", SDKHook_PreThink, SDKHookCB_Client_PreThink);
+	SDKHooks_AddHook("player", SDKHook_PreThinkPost, SDKHookCB_Client_PreThinkPost);
+	SDKHooks_AddHook("player", SDKHook_PostThink, SDKHookCB_Client_PostThink);
+	SDKHooks_AddHook("player", SDKHook_PostThinkPost, SDKHookCB_Client_PostThinkPost);
+	SDKHooks_AddHook("player", SDKHook_OnTakeDamage, SDKHookCB_Client_OnTakeDamage);
+	SDKHooks_AddHook("player", SDKHook_OnTakeDamagePost, SDKHookCB_Client_OnTakeDamagePost);
+	SDKHooks_AddHook("player", SDKHook_SetTransmit, SDKHookCB_Client_SetTransmit);
+	
 	// Makes objects solid to teammates
-	if (!strncmp(classname, "obj_", 4))
-	{
-		SDKHook(entity, SDKHook_SpawnPost, SDKHookCB_Object_SpawnPost);
-	}
+	SDKHooks_AddHook("obj_*", SDKHook_SpawnPost, SDKHookCB_Object_SpawnPost);
 	
 	// Prevents Dispensers from healing teammates
-	if (StrEqual(classname, "obj_dispenser") || StrEqual(classname, "pd_dispenser"))
-	{
-		SDKHook(entity, SDKHook_StartTouch, SDKHookCB_ObjectDispenser_StartTouch);
-		SDKHook(entity, SDKHook_StartTouchPost, SDKHookCB_ObjectDispenser_StartTouchPost);
-	}
+	SDKHooks_AddHook("obj_dispenser", SDKHook_StartTouch, SDKHookCB_ObjectDispenser_StartTouch);
+	SDKHooks_AddHook("pd_dispenser", SDKHook_StartTouchPost, SDKHookCB_ObjectDispenser_StartTouchPost);
 	
 	// Fixes the cleaver and pipes dealing no damage to certain entities
-	if (StrEqual(classname, "tf_projectile_cleaver") || StrEqual(classname, "tf_projectile_pipe"))
-	{
-		SDKHook(entity, SDKHook_Touch, SDKHookCB_Projectile_Touch);
-		SDKHook(entity, SDKHook_TouchPost, SDKHookCB_Projectile_TouchPost);
-	}
+	SDKHooks_AddHook("tf_projectile_cleaver", SDKHook_Touch, SDKHookCB_Projectile_Touch);
+	SDKHooks_AddHook("tf_projectile_cleaver", SDKHook_TouchPost, SDKHookCB_Projectile_TouchPost);
+	SDKHooks_AddHook("tf_projectile_pipe", SDKHook_Touch, SDKHookCB_Projectile_Touch);
+	SDKHooks_AddHook("tf_projectile_pipe", SDKHook_TouchPost, SDKHookCB_Projectile_TouchPost);
 	
 	// Allows detonating teammate's pipebombs
-	if (StrEqual(classname, "tf_projectile_pipe_remote"))
-	{
-		SDKHook(entity, SDKHook_OnTakeDamage, SDKHookCB_ProjectilePipeRemote_OnTakeDamage);
-		SDKHook(entity, SDKHook_OnTakeDamagePost, SDKHookCB_ProjectilePipeRemote_OnTakeDamagePost);
-	}
+	SDKHooks_AddHook("tf_projectile_pipe_remote", SDKHook_OnTakeDamage, SDKHookCB_ProjectilePipeRemote_OnTakeDamage);
+	SDKHooks_AddHook("tf_projectile_pipe_remote", SDKHook_OnTakeDamagePost, SDKHookCB_ProjectilePipeRemote_OnTakeDamagePost);
 	
 	// Fixes Flame Throwers dealing no damage to teammates
-	if (StrEqual(classname, "tf_flame_manager"))
-	{
-		SDKHook(entity, SDKHook_Touch, SDKHookCB_FlameManager_Touch);
-		SDKHook(entity, SDKHook_TouchPost, SDKHookCB_FlameManager_TouchPost);
-	}
+	SDKHooks_AddHook("tf_flame_manager", SDKHook_Touch, SDKHookCB_FlameManager_Touch);
+	SDKHooks_AddHook("tf_flame_manager", SDKHook_TouchPost, SDKHookCB_FlameManager_TouchPost);
 	
 	// Prevents Gas Passer clouds from coating the thrower
-	if (StrEqual(classname, "tf_gas_manager"))
+	SDKHooks_AddHook("tf_gas_manager", SDKHook_Touch, SDKHookCB_GasManager_Touch);
+}
+
+void SDKHooks_Toggle(bool enable)
+{
+	int entity = -1;
+	while ((entity = FindEntityByClassname(entity, "*")) != -1)
 	{
-		SDKHook(entity, SDKHook_Touch, SDKHookCB_GasManager_Touch);
+		char classname[64];
+		if (!GetEntityClassname(entity, classname, sizeof(classname)))
+			continue;
+		
+		SDKHooks_HookEntity(entity, classname, enable);
 	}
 }
 
-static void SDKHooks_AddHook(SDKHookType type, SDKHookCB callback)
+void SDKHooks_HookEntity(int entity, const char[] classname, bool hook)
+{
+	for (int i = 0; i < g_hookData.Length; i++)
+	{
+		SDKHookData data;
+		if (!g_hookData.GetArray(i, data))
+			continue;
+		
+		int index = StrContains(data.classname, "*");
+		if (index != -1)
+		{
+			data.classname[index] = EOS;
+		}
+		
+		if (index != -1 && !strncmp(classname, data.classname, index) || StrEqual(data.classname, classname))
+		{
+			if (hook)
+			{
+				SDKHook(entity, data.type, data.callback);
+			}
+			else
+			{
+				SDKUnhook(entity, data.type, data.callback);
+			}
+		}
+	}
+}
+
+static void SDKHooks_AddHook(const char[] classname, SDKHookType type, SDKHookCB callback)
 {
 	SDKHookData data;
+	strcopy(data.classname, sizeof(data.classname), classname);
 	data.type = type;
 	data.callback = callback;
 	

--- a/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
@@ -109,13 +109,7 @@ void SDKHooks_HookEntity(int entity, const char[] classname)
 			SDKHooks_HookEntityInternal(entity, SDKHook_SpawnPost, SDKHookCB_Object_SpawnPost);
 		}
 		
-		if (StrEqual(classname, "obj_dispenser") || StrEqual(classname, "pd_dispenser"))
-		{
-			// Prevents Dispensers from healing teammates
-			SDKHooks_HookEntityInternal(entity, SDKHook_StartTouch, SDKHookCB_ObjectDispenser_StartTouch);
-			SDKHooks_HookEntityInternal(entity, SDKHook_StartTouchPost, SDKHookCB_ObjectDispenser_StartTouchPost);
-		}
-		else if (!strncmp(classname, "tf_projectile_", 14))
+		if (!strncmp(classname, "tf_projectile_", 14))
 		{
 			if (StrEqual(classname, "tf_projectile_cleaver") || StrEqual(classname, "tf_projectile_pipe"))
 			{
@@ -129,6 +123,12 @@ void SDKHooks_HookEntity(int entity, const char[] classname)
 				SDKHooks_HookEntityInternal(entity, SDKHook_OnTakeDamage, SDKHookCB_ProjectilePipeRemote_OnTakeDamage);
 				SDKHooks_HookEntityInternal(entity, SDKHook_OnTakeDamagePost, SDKHookCB_ProjectilePipeRemote_OnTakeDamagePost);
 			}
+		}
+		else if (StrEqual(classname, "obj_dispenser") || StrEqual(classname, "pd_dispenser"))
+		{
+			// Prevents Dispensers from healing teammates
+			SDKHooks_HookEntityInternal(entity, SDKHook_StartTouch, SDKHookCB_ObjectDispenser_StartTouch);
+			SDKHooks_HookEntityInternal(entity, SDKHook_StartTouchPost, SDKHookCB_ObjectDispenser_StartTouchPost);
 		}
 		else if (StrEqual(classname, "tf_flame_manager"))
 		{

--- a/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
@@ -174,7 +174,7 @@ static void SDKHooks_HookEntityInternal(int entity, SDKHookType type, SDKHookCB 
 // CTFPlayerShared::OnPreDataChanged
 static void SDKHookCB_Client_PreThink(int client)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return;
 	
 	// Disable radius buffs like Buff Banner or King Rune
@@ -184,7 +184,7 @@ static void SDKHookCB_Client_PreThink(int client)
 // CTFPlayerShared::OnPreDataChanged
 static void SDKHookCB_Client_PreThinkPost(int client)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return;
 	
 	Entity(client).ResetTeam();
@@ -193,7 +193,7 @@ static void SDKHookCB_Client_PreThinkPost(int client)
 // CTFWeaponBase::ItemPostFrame
 static void SDKHookCB_Client_PostThink(int client)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return;
 	
 	// CTFPlayer::DoTauntAttack
@@ -249,7 +249,7 @@ static void SDKHookCB_Client_PostThink(int client)
 // CTFWeaponBase::ItemPostFrame
 static void SDKHookCB_Client_PostThinkPost(int client)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return;
 	
 	// Change everything back to how it was accordingly
@@ -277,7 +277,7 @@ static void SDKHookCB_Client_PostThinkPost(int client)
 
 static Action SDKHookCB_Client_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return Plugin_Continue;
 	
 	// Attacker and victim are commonly modified by other plugins, store them off
@@ -299,7 +299,7 @@ static Action SDKHookCB_Client_OnTakeDamage(int victim, int &attacker, int &infl
 
 static void SDKHookCB_Client_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return;
 	
 	g_hookParams_OnTakeDamage.GetValue("victim", victim);
@@ -317,7 +317,7 @@ static void SDKHookCB_Client_OnTakeDamagePost(int victim, int attacker, int infl
 
 static Action SDKHookCB_Client_SetTransmit(int entity, int client)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return Plugin_Continue;
 	
 	// Don't transmit invisible spies to living players
@@ -332,7 +332,7 @@ static Action SDKHookCB_Client_SetTransmit(int entity, int client)
 
 static Action SDKHookCB_ObjectDispenser_StartTouch(int entity, int other)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return Plugin_Continue;
 	
 	if (IsEntityClient(other) && !IsObjectFriendly(entity, other))
@@ -345,7 +345,7 @@ static Action SDKHookCB_ObjectDispenser_StartTouch(int entity, int other)
 
 static void SDKHookCB_ObjectDispenser_StartTouchPost(int entity, int other)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return;
 	
 	if (IsEntityClient(other) && !IsObjectFriendly(entity, other))
@@ -356,7 +356,7 @@ static void SDKHookCB_ObjectDispenser_StartTouchPost(int entity, int other)
 
 static void SDKHookCB_Object_SpawnPost(int entity)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return;
 	
 	// Enable collisions for both teams
@@ -366,7 +366,7 @@ static void SDKHookCB_Object_SpawnPost(int entity)
 
 static Action SDKHookCB_Projectile_Touch(int entity, int other)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return Plugin_Continue;
 	
 	if (other == 0)
@@ -384,7 +384,7 @@ static Action SDKHookCB_Projectile_Touch(int entity, int other)
 
 static void SDKHookCB_Projectile_TouchPost(int entity, int other)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return;
 	
 	if (other == 0)
@@ -400,7 +400,7 @@ static void SDKHookCB_Projectile_TouchPost(int entity, int other)
 
 static Action SDKHookCB_ProjectilePipeRemote_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return Plugin_Continue;
 	
 	if (attacker != -1)
@@ -418,7 +418,7 @@ static Action SDKHookCB_ProjectilePipeRemote_OnTakeDamage(int victim, int &attac
 
 static void SDKHookCB_ProjectilePipeRemote_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return;
 	
 	if (attacker != -1)
@@ -432,7 +432,7 @@ static void SDKHookCB_ProjectilePipeRemote_OnTakeDamagePost(int victim, int atta
 
 static Action SDKHookCB_FlameManager_Touch(int entity, int other)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return Plugin_Continue;
 	
 	int owner = FindParentOwnerEntity(entity);
@@ -447,7 +447,7 @@ static Action SDKHookCB_FlameManager_Touch(int entity, int other)
 
 static void SDKHookCB_FlameManager_TouchPost(int entity, int other)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return;
 	
 	int owner = FindParentOwnerEntity(entity);
@@ -459,7 +459,7 @@ static void SDKHookCB_FlameManager_TouchPost(int entity, int other)
 
 static Action SDKHookCB_GasManager_Touch(int entity, int other)
 {
-	if (!IsTruceActive())
+	if (IsTruceActive())
 		return Plugin_Continue;
 	
 	if (FindParentOwnerEntity(entity) == other)

--- a/addons/sourcemod/scripting/friendlyfire/util.sp
+++ b/addons/sourcemod/scripting/friendlyfire/util.sp
@@ -22,7 +22,7 @@ static RoundState g_roundState;
 
 bool IsTruceActive()
 {
-	return !GameRules_GetProp("m_bTruceActive");
+	return GameRules_GetProp("m_bTruceActive") != 0;
 }
 
 TFTeam TF2_GetEntityTeam(int entity)

--- a/addons/sourcemod/scripting/friendlyfire/util.sp
+++ b/addons/sourcemod/scripting/friendlyfire/util.sp
@@ -20,9 +20,9 @@
 
 static RoundState g_roundState;
 
-bool IsFriendlyFireEnabled()
+bool IsTruceActive()
 {
-	return g_isEnabled && !GameRules_GetProp("m_bTruceActive");
+	return !GameRules_GetProp("m_bTruceActive");
 }
 
 TFTeam TF2_GetEntityTeam(int entity)

--- a/addons/sourcemod/scripting/friendlyfire/util.sp
+++ b/addons/sourcemod/scripting/friendlyfire/util.sp
@@ -118,17 +118,17 @@ float GetPercentInvisible(int client)
 	return GetEntDataFloat(client, offset);
 }
 
-bool IsBaseObject(int entity)
+bool IsEntityBaseObject(int entity)
 {
 	return HasEntProp(entity, Prop_Data, "CBaseObjectUpgradeThink");
 }
 
-bool IsWeaponBaseMelee(int entity)
+bool IsEntityBaseMelee(int entity)
 {
 	return HasEntProp(entity, Prop_Data, "CTFWeaponBaseMeleeSmack");
 }
 
-bool IsProjectileCTFWeaponBaseGrenade(int entity)
+bool IsEntityBaseGrenadeProjectile(int entity)
 {
 	return HasEntProp(entity, Prop_Data, "CTFWeaponBaseGrenadeProjDetonateThink");
 }


### PR DESCRIPTION
Replaces our old hook system with a registry that keeps track of active hooks and will evict them if the associated entity is deleted. This allows us to improve per-frame performance ever so slightly, and is also just nicer to work with.