### PR TITLE
Fix deflected projectiles being in spectator team

### DIFF
--- a/addons/sourcemod/gamedata/friendlyfire.txt
+++ b/addons/sourcemod/gamedata/friendlyfire.txt
@@ -132,6 +132,12 @@
 				"linux"		"293"
 				"windows"	"287"
 			}
+			"CBaseEntity::Deflected"
+			{
+				"library"	"server"
+				"linux"		"160"
+				"windows"	"159"
+			}
 			"CBaseEntity::VPhysicsUpdate"
 			{
 				"library"	"server"
@@ -246,6 +252,24 @@
 				"hooktype"	"entity"
 				"return"	"void"
 				"this"		"entity"
+			}
+			"CBaseEntity::Deflected"
+			{
+				"offset"	"CBaseEntity::Deflected"
+				"hooktype"	"entity"
+				"return"	"void"
+				"this"		"entity"
+				"arguments"
+				{
+					"pDeflectedBy"
+					{
+						"type"	"cbaseentity"
+					}
+					"vecDir"
+					{
+						"type"	"vectorptr"
+					}
+				}
 			}
 			"CBaseEntity::VPhysicsUpdate"
 			{

--- a/addons/sourcemod/scripting/friendlyfire.sp
+++ b/addons/sourcemod/scripting/friendlyfire.sp
@@ -25,7 +25,7 @@
 #include <tf2_stocks>
 #include <tf2utils>
 
-#define PLUGIN_VERSION	"1.2.5"
+#define PLUGIN_VERSION	"1.2.6"
 
 #define TICK_NEVER_THINK	-1.0
 #define TF_CUSTOM_NONE		0


### PR DESCRIPTION
Due to the nature of the airblast fix, any projectiles reflected with airblast would be in the spectator team, causing wrong visuals.

This PR fixes the issue by resetting the deflector's team back to what it was during `CBaseEntity::Deflected`.