### PR TITLE
Don't run damage logic on self-damage

### DIFF
--- a/addons/sourcemod/scripting/friendlyfire.sp
+++ b/addons/sourcemod/scripting/friendlyfire.sp
@@ -25,7 +25,7 @@
 #include <tf2_stocks>
 #include <tf2utils>
 
-#define PLUGIN_VERSION	"1.2.8"
+#define PLUGIN_VERSION	"1.2.9"
 
 #define TICK_NEVER_THINK	-1.0
 #define TF_CUSTOM_NONE		0

--- a/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
@@ -252,6 +252,9 @@ static Action SDKHookCB_Client_OnTakeDamage(int victim, int &attacker, int &infl
 	if (IsTruceActive())
 		return Plugin_Continue;
 	
+	if (victim == attacker)
+		return Plugin_Continue;
+	
 	// Attacker and victim are commonly modified by other plugins, store them off
 	g_hookParams_OnTakeDamage.SetValue("victim", victim);
 	g_hookParams_OnTakeDamage.SetValue("attacker", attacker);
@@ -272,6 +275,9 @@ static Action SDKHookCB_Client_OnTakeDamage(int victim, int &attacker, int &infl
 static void SDKHookCB_Client_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype)
 {
 	if (IsTruceActive())
+		return;
+	
+	if (victim == attacker)
 		return;
 	
 	g_hookParams_OnTakeDamage.GetValue("victim", victim);


### PR DESCRIPTION
Weapons like the Half-Zatoichi are really weird and will deal self-damage on holster while the player is dead (though it is set to 0.0). This somehow causes the attacker and victim to change between the pre-hook and post-hook, which messes up the chain. Ironically, my system to foolproof against other plugins bites me in the ass here.

Closes #15