### PR TITLE
Improve truce support

### DIFF
--- a/addons/sourcemod/gamedata/friendlyfire.txt
+++ b/addons/sourcemod/gamedata/friendlyfire.txt
@@ -45,6 +45,12 @@
 				"linux"		"@_ZNK11CBaseEntity10InSameTeamEPKS_"
 				"windows"	"\x55\x8B\xEC\x8B\x45\x08\x57\x8B\xF9\x85\xC0\x75\x2A"
 			}
+			"CTFPlayerShared::StunPlayer"
+			{
+				"library"	"server"
+				"linux"		"@_ZN15CTFPlayerShared10StunPlayerEffiP9CTFPlayer"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x24\x57\x8B\xF9\x8B\x87\xDC\x04\x00\x00"
+			}
 			"GetGlobalTeam"
 			{
 				"library"	"server"
@@ -71,6 +77,12 @@
 				"library"	"server"
 				"linux"		"230"
 				"windows"	"229"
+			}
+			"CTFWeaponBase::DeflectProjectiles"
+			{
+				"library"	"server"
+				"linux"		"426"
+				"windows"	"419"
 			}
 			"CTFSniperRifle::GetCustomDamageType"
 			{
@@ -218,6 +230,13 @@
 				"return"	"bool"
 				"this"		"entity"
 			}
+			"CTFWeaponBase::DeflectProjectiles"
+			{
+				"offset"	"CTFWeaponBase::DeflectProjectiles"
+				"hooktype"	"entity"
+				"return"	"bool"
+				"this"		"entity"
+			}
 			"CTFSniperRifle::GetCustomDamageType"
 			{
 				"offset"	"CTFSniperRifle::GetCustomDamageType"
@@ -294,6 +313,32 @@
 				"arguments"
 				{
 					"pEntity"
+					{
+						"type"	"cbaseentity"
+					}
+				}
+			}
+			"CTFPlayerShared::StunPlayer"
+			{
+				"signature"	"CTFPlayerShared::StunPlayer"
+				"callconv"	"thiscall"
+				"return"	"void"
+				"this"		"address"
+				"arguments"
+				{
+					"flTime"
+					{
+						"type"	"float"
+					}
+					"flReductionAmount"
+					{
+						"type"	"float"
+					}
+					"iStunFlags"
+					{
+						"type"	"int"
+					}
+					"pAttacker"
 					{
 						"type"	"cbaseentity"
 					}

--- a/addons/sourcemod/gamedata/friendlyfire.txt
+++ b/addons/sourcemod/gamedata/friendlyfire.txt
@@ -45,6 +45,12 @@
 				"linux"		"@_ZNK11CBaseEntity10InSameTeamEPKS_"
 				"windows"	"\x55\x8B\xEC\x8B\x45\x08\x57\x8B\xF9\x85\xC0\x75\x2A"
 			}
+			"CTFPlayer::ApplyGenericPushbackImpulse"
+			{
+				"library"	"server"
+				"linux"		"@_ZN9CTFPlayer27ApplyGenericPushbackImpulseERK6VectorPS_"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x0C\x53\x57\x8B\xF9\x8D\x8F\xE0\x1A\x00\x00"
+			}
 			"CTFPlayerShared::StunPlayer"
 			{
 				"library"	"server"
@@ -313,6 +319,24 @@
 				"arguments"
 				{
 					"pEntity"
+					{
+						"type"	"cbaseentity"
+					}
+				}
+			}
+			"CTFPlayer::ApplyGenericPushbackImpulse"
+			{
+				"signature"	"CTFPlayer::ApplyGenericPushbackImpulse"
+				"callconv"	"thiscall"
+				"return"	"void"
+				"this"		"entity"
+				"arguments"
+				{
+					"vecImpulse"
+					{
+						"type"	"vectorptr"
+					}
+					"pAttacker"
 					{
 						"type"	"cbaseentity"
 					}

--- a/addons/sourcemod/scripting/friendlyfire.sp
+++ b/addons/sourcemod/scripting/friendlyfire.sp
@@ -26,7 +26,7 @@
 #include <tf2utils>
 #include <pluginstatemanager>
 
-#define PLUGIN_VERSION	"1.2.10"
+#define PLUGIN_VERSION	"1.3.0"
 
 #define TICK_NEVER_THINK	-1.0
 #define TF_CUSTOM_NONE		0

--- a/addons/sourcemod/scripting/friendlyfire/dhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/dhooks.sp
@@ -549,6 +549,9 @@ static MRESReturn DHookCallback_CWeaponMedigun_AllowedToHealTarget_Post(int medi
 
 static MRESReturn DHookCallback_CTFPlayerShared_StunPlayer_Pre(Address shared, DHookParam params)
 {
+	if (params.IsNull(4))
+		return MRES_Ignored;
+	
 	int attacker = params.Get(4);
 	if (IsEntityClient(attacker))
 		Entity(attacker).ChangeToOriginalTeam();
@@ -558,6 +561,9 @@ static MRESReturn DHookCallback_CTFPlayerShared_StunPlayer_Pre(Address shared, D
 
 static MRESReturn DHookCallback_CTFPlayerShared_StunPlayer_Post(Address shared, DHookParam params)
 {
+	if (params.IsNull(4))
+		return MRES_Ignored;
+	
 	int attacker = params.Get(4);
 	if (IsEntityClient(attacker))
 		Entity(attacker).ResetTeam();

--- a/addons/sourcemod/scripting/friendlyfire/dhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/dhooks.sp
@@ -572,7 +572,6 @@ static MRESReturn DHookCallback_CTFPlayer_ApplyGenericPushbackImpulse_Post(int p
 	
 	int attacker = params.Get(2);
 	
-	// DeflectProjectiles checks the enemy team of each entity in the box
 	Entity(attacker).ResetTeam();
 	
 	for (int client = 1; client <= MaxClients; client++)

--- a/addons/sourcemod/scripting/friendlyfire/dhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/dhooks.sp
@@ -153,13 +153,10 @@ static MRESReturn DHookCallback_CTFWeaponBase_DeflectProjectiles_Pre(int weapon,
 		
 		for (int client = 1; client <= MaxClients; client++)
 		{
-			if (!IsClientInGame(client))
-				continue;
-			
-			if (client == owner)
-				continue;
-			
-			Entity(client).SetTeam(enemyTeam);
+			if (IsClientInGame(client) && client != owner)
+			{
+				Entity(client).SetTeam(enemyTeam);
+			}
 		}
 	}
 	
@@ -175,13 +172,10 @@ static MRESReturn DHookCallback_CTFWeaponBase_DeflectProjectiles_Post(int weapon
 		
 		for (int client = 1; client <= MaxClients; client++)
 		{
-			if (!IsClientInGame(client))
-				continue;
-			
-			if (client == owner)
-				continue;
-			
-			Entity(client).ResetTeam();
+			if (IsClientInGame(client) && client != owner)
+			{
+				Entity(client).ResetTeam();
+			}
 		}
 	}
 	
@@ -562,13 +556,10 @@ static MRESReturn DHookCallback_CTFPlayer_ApplyGenericPushbackImpulse_Pre(int pl
 	
 	for (int client = 1; client <= MaxClients; client++)
 	{
-		if (!IsClientInGame(client))
-			continue;
-		
-		if (client == attacker)
-			continue;
-		
-		Entity(client).SetTeam(enemyTeam);
+		if (IsClientInGame(client) && client != attacker)
+		{
+			Entity(client).SetTeam(enemyTeam);
+		}
 	}
 	
 	return MRES_Ignored;
@@ -586,13 +577,10 @@ static MRESReturn DHookCallback_CTFPlayer_ApplyGenericPushbackImpulse_Post(int p
 	
 	for (int client = 1; client <= MaxClients; client++)
 	{
-		if (!IsClientInGame(client))
-			continue;
-		
-		if (client == attacker)
-			continue;
-		
-		Entity(client).ResetTeam();
+		if (IsClientInGame(client) && client != attacker)
+		{
+			Entity(client).ResetTeam();
+		}
 	}
 	
 	return MRES_Ignored;

--- a/addons/sourcemod/scripting/friendlyfire/dhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/dhooks.sp
@@ -31,6 +31,7 @@ static DynamicHook g_dhook_CTFSniperRifle_GetCustomDamageType;
 static DynamicHook g_dhook_CBaseGrenade_Explode;
 static DynamicHook g_dhook_CTFBaseRocket_Explode;
 static DynamicHook g_dhook_CBasePlayer_Event_Killed;
+static DynamicHook g_dhook_CTFWeaponBase_DeflectProjectiles;
 static DynamicHook g_dhook_CTFWeaponBaseMelee_Smack;
 static DynamicHook g_dhook_CTFWeaponBase_SecondaryAttack;
 static DynamicHook g_dhook_CBaseEntity_Deflected;
@@ -44,12 +45,14 @@ void DHooks_Init()
 	PSM_AddDynamicDetourFromConf("CBaseEntity::InSameTeam", DHookCallback_CBaseEntity_InSameTeam_Pre);
 	PSM_AddDynamicDetourFromConf("CBaseEntity::PhysicsDispatchThink", DHookCallback_CBaseEntity_PhysicsDispatchThink_Pre, DHookCallback_CBaseEntity_PhysicsDispatchThink_Post);
 	PSM_AddDynamicDetourFromConf("CWeaponMedigun::AllowedToHealTarget", DHookCallback_CWeaponMedigun_AllowedToHealTarget_Pre, DHookCallback_CWeaponMedigun_AllowedToHealTarget_Post);
+	PSM_AddDynamicDetourFromConf("CTFPlayerShared::StunPlayer", DHookCallback_CTFPlayerShared_StunPlayer_Pre, DHookCallback_CTFPlayerShared_StunPlayer_Post);
 	
 	g_dhook_CBaseProjectile_CanCollideWithTeammates = PSM_AddDynamicHookFromConf("CBaseProjectile::CanCollideWithTeammates");
 	g_dhook_CTFSniperRifle_GetCustomDamageType = PSM_AddDynamicHookFromConf("CTFSniperRifle::GetCustomDamageType");
 	g_dhook_CBaseGrenade_Explode = PSM_AddDynamicHookFromConf("CBaseGrenade::Explode");
 	g_dhook_CTFBaseRocket_Explode = PSM_AddDynamicHookFromConf("CTFBaseRocket::Explode");
 	g_dhook_CBasePlayer_Event_Killed = PSM_AddDynamicHookFromConf("CBasePlayer::Event_Killed");
+	g_dhook_CTFWeaponBase_DeflectProjectiles = PSM_AddDynamicHookFromConf("CTFWeaponBase::DeflectProjectiles");
 	g_dhook_CTFWeaponBaseMelee_Smack = PSM_AddDynamicHookFromConf("CTFWeaponBaseMelee::Smack");
 	g_dhook_CTFWeaponBase_SecondaryAttack = PSM_AddDynamicHookFromConf("CTFWeaponBase::SecondaryAttack");
 	g_dhook_CBaseEntity_Deflected = PSM_AddDynamicHookFromConf("CBaseEntity::Deflected");
@@ -95,6 +98,9 @@ void DHooks_OnEntityCreated(int entity, const char[] classname)
 	}
 	else if (TF2Util_IsEntityWeapon(entity))
 	{
+		PSM_DHookEntity(g_dhook_CTFWeaponBase_DeflectProjectiles, Hook_Pre, entity, DHookCallback_CTFWeaponBase_DeflectProjectiles_Pre);
+		PSM_DHookEntity(g_dhook_CTFWeaponBase_DeflectProjectiles, Hook_Post, entity, DHookCallback_CTFWeaponBase_DeflectProjectiles_Post);
+		
 		if (IsEntityBaseMelee(entity))
 		{
 			// Fixes wrenches not being able to upgrade friendly objects, as well as a few other melee weapons
@@ -121,9 +127,6 @@ void DHooks_OnEntityCreated(int entity, const char[] classname)
 
 static MRESReturn DHookCallback_CTFPlayer_Event_Killed_Pre(int player, DHookParam params)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	// Switch back to the original team to force proper skin for ragdolls and other on-death effects
 	Entity(player).ChangeToOriginalTeam();
 	
@@ -132,19 +135,59 @@ static MRESReturn DHookCallback_CTFPlayer_Event_Killed_Pre(int player, DHookPara
 
 static MRESReturn DHookCallback_CTFPlayer_Event_Killed_Post(int player, DHookParam params)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	Entity(player).ResetTeam();
+	
+	return MRES_Ignored;
+}
+
+static MRESReturn DHookCallback_CTFWeaponBase_DeflectProjectiles_Pre(int weapon, DHookReturn ret)
+{
+	int owner = GetEntPropEnt(weapon, Prop_Send, "m_hOwner");
+	if (IsEntityClient(owner))
+	{
+		// DeflectProjectiles checks the enemy team of each entity in the box
+		Entity(owner).ChangeToOriginalTeam();
+		TFTeam enemyTeam = GetEnemyTeam(TF2_GetClientTeam(owner));
+		
+		for (int client = 1; client <= MaxClients; client++)
+		{
+			if (!IsClientInGame(client))
+				continue;
+			
+			if (client == owner)
+				continue;
+			
+			Entity(client).SetTeam(enemyTeam);
+		}
+	}
+	
+	return MRES_Ignored;
+}
+
+static MRESReturn DHookCallback_CTFWeaponBase_DeflectProjectiles_Post(int weapon, DHookReturn ret)
+{
+	int owner = GetEntPropEnt(weapon, Prop_Send, "m_hOwner");
+	if (IsEntityClient(owner))
+	{
+		Entity(owner).ResetTeam();
+		
+		for (int client = 1; client <= MaxClients; client++)
+		{
+			if (!IsClientInGame(client))
+				continue;
+			
+			if (client == owner)
+				continue;
+			
+			Entity(client).ResetTeam();
+		}
+	}
 	
 	return MRES_Ignored;
 }
 
 static MRESReturn DHookCallback_CTFProjectile_Jar_Explode_Pre(int entity, DHookParam params)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	int thrower = GetEntPropEnt(entity, Prop_Send, "m_hThrower");
 	if (thrower != -1)
 	{
@@ -157,9 +200,6 @@ static MRESReturn DHookCallback_CTFProjectile_Jar_Explode_Pre(int entity, DHookP
 
 static MRESReturn DHookCallback_CTFProjectile_Jar_Explode_Post(int entity, DHookParam params)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	int thrower = GetEntPropEnt(entity, Prop_Send, "m_hThrower");
 	if (thrower != -1)
 	{
@@ -172,9 +212,6 @@ static MRESReturn DHookCallback_CTFProjectile_Jar_Explode_Post(int entity, DHook
 
 static MRESReturn DHookCallback_CTFProjectile_Flare_Explode_Pre(int entity, DHookParam params)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	if (!params.IsNull(2))
 		Entity(params.Get(2)).ChangeToSpectator();
 	
@@ -183,9 +220,6 @@ static MRESReturn DHookCallback_CTFProjectile_Flare_Explode_Pre(int entity, DHoo
 
 static MRESReturn DHookCallback_CTFProjectile_Flare_Explode_Post(int entity, DHookParam params)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	if (!params.IsNull(2))
 		Entity(params.Get(2)).ResetTeam();
 	
@@ -194,9 +228,6 @@ static MRESReturn DHookCallback_CTFProjectile_Flare_Explode_Post(int entity, DHo
 
 static MRESReturn DHookCallback_CBaseProjectile_CanCollideWithTeammates_Post(int entity, DHookReturn ret)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	// Always make projectiles collide with teammates
 	ret.Value = true;
 	
@@ -205,9 +236,6 @@ static MRESReturn DHookCallback_CBaseProjectile_CanCollideWithTeammates_Post(int
 
 static MRESReturn DHookCallback_CBaseEntity_Deflected_Pre(int entity, DHookParam params)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	// Make projectiles have the original team of the deflector
 	if (!params.IsNull(1))
 		Entity(params.Get(1)).ChangeToOriginalTeam();
@@ -217,9 +245,6 @@ static MRESReturn DHookCallback_CBaseEntity_Deflected_Pre(int entity, DHookParam
 
 static MRESReturn DHookCallback_CBaseEntity_Deflected_Post(int entity, DHookParam params)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	if (!params.IsNull(1))
 		Entity(params.Get(1)).ResetTeam();
 	
@@ -228,9 +253,6 @@ static MRESReturn DHookCallback_CBaseEntity_Deflected_Post(int entity, DHookPara
 
 static MRESReturn DHookCallback_CTFSniperRifle_GetCustomDamageType_Post(int entity, DHookReturn ret)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	// Allows Sniper Rifles to hit teammates, without breaking Machina penetration
 	int penetrateType = SDKCall_CTFSniperRifle_GetPenetrateType(entity);
 	if (penetrateType == TF_CUSTOM_NONE)
@@ -244,9 +266,6 @@ static MRESReturn DHookCallback_CTFSniperRifle_GetCustomDamageType_Post(int enti
 
 static MRESReturn DHookCallback_CTFWeaponBaseMelee_Smack_Pre(int entity)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	int owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
 	if (owner != -1)
 	{
@@ -271,9 +290,6 @@ static MRESReturn DHookCallback_CTFWeaponBaseMelee_Smack_Pre(int entity)
 
 static MRESReturn DHookCallback_CTFWeaponBaseMelee_Smack_Post(int entity)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	int owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
 	if (owner != -1)
 	{
@@ -297,9 +313,6 @@ static MRESReturn DHookCallback_CTFWeaponBaseMelee_Smack_Post(int entity)
 
 static MRESReturn DHookCallback_CBaseEntity_InSameTeam_Pre(int entity, DHookReturn ret, DHookParam params)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	if (g_disableInSameTeamDetour)
 		return MRES_Ignored;
 	
@@ -336,9 +349,6 @@ static MRESReturn DHookCallback_CBaseEntity_InSameTeam_Pre(int entity, DHookRetu
 
 static MRESReturn DHookCallback_CBaseEntity_PhysicsDispatchThink_Pre(int entity)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	char classname[64];
 	if (!GetEntityClassname(entity, classname, sizeof(classname)))
 		return MRES_Ignored;
@@ -446,9 +456,6 @@ static MRESReturn DHookCallback_CBaseEntity_PhysicsDispatchThink_Pre(int entity)
 
 static MRESReturn DHookCallback_CBaseEntity_PhysicsDispatchThink_Post(int entity)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	switch (g_thinkFunction)
 	{
 		case ThinkFunction_SentryThink:
@@ -525,9 +532,6 @@ static MRESReturn DHookCallback_CBaseEntity_PhysicsDispatchThink_Post(int entity
 
 static MRESReturn DHookCallback_CWeaponMedigun_AllowedToHealTarget_Pre(int medigun, DHookReturn ret, DHookParam params)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	// Temporarily disable our CBaseEntity::InSameTeam detour to allow healing teammates
 	if (FindConVar("sm_friendlyfire_medic_allow_healing").BoolValue)
 		g_disableInSameTeamDetour = true;
@@ -537,20 +541,32 @@ static MRESReturn DHookCallback_CWeaponMedigun_AllowedToHealTarget_Pre(int medig
 
 static MRESReturn DHookCallback_CWeaponMedigun_AllowedToHealTarget_Post(int medigun, DHookReturn ret, DHookParam params)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	if (FindConVar("sm_friendlyfire_medic_allow_healing").BoolValue)
 		g_disableInSameTeamDetour = false;
 	
 	return MRES_Ignored;
 }
 
+static MRESReturn DHookCallback_CTFPlayerShared_StunPlayer_Pre(Address shared, DHookParam params)
+{
+	int attacker = params.Get(4);
+	if (IsEntityClient(attacker))
+		Entity(attacker).ChangeToOriginalTeam();
+	
+	return MRES_Ignored;
+}
+
+static MRESReturn DHookCallback_CTFPlayerShared_StunPlayer_Post(Address shared, DHookParam params)
+{
+	int attacker = params.Get(4);
+	if (IsEntityClient(attacker))
+		Entity(attacker).ResetTeam();
+	
+	return MRES_Ignored;
+}
+
 static MRESReturn DHookCallback_CTFPipebombLauncher_SecondaryAttack_Pre(int weapon)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	// Switch the weapon
 	Entity(weapon).ChangeToSpectator();
 	
@@ -577,9 +593,6 @@ static MRESReturn DHookCallback_CTFPipebombLauncher_SecondaryAttack_Pre(int weap
 
 static MRESReturn DHookCallback_CTFPipebombLauncher_SecondaryAttack_Post(int weapon)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	Entity(weapon).ResetTeam();
 	
 	int owner = GetEntPropEnt(weapon, Prop_Send, "m_hOwnerEntity");
@@ -603,9 +616,6 @@ static MRESReturn DHookCallback_CTFPipebombLauncher_SecondaryAttack_Post(int wea
 
 static MRESReturn DHookCallback_CTFWeaponBaseGrenadeProj_VPhysicsUpdate_Pre(int entity, DHookParam params)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	int thrower = GetEntPropEnt(entity, Prop_Send, "m_hThrower");
 	TFTeam enemyTeam = GetEnemyTeam(TF2_GetEntityTeam(entity));
 	
@@ -633,9 +643,6 @@ static MRESReturn DHookCallback_CTFWeaponBaseGrenadeProj_VPhysicsUpdate_Pre(int 
 
 static MRESReturn DHookCallback_CTFWeaponBaseGrenade_VPhysicsUpdate_Post(int entity, DHookParam params)
 {
-	if (IsTruceActive())
-		return MRES_Ignored;
-	
 	int thrower = GetEntPropEnt(entity, Prop_Send, "m_hThrower");
 	
 	for (int client = 1; client <= MaxClients; client++)

--- a/addons/sourcemod/scripting/friendlyfire/entity.sp
+++ b/addons/sourcemod/scripting/friendlyfire/entity.sp
@@ -125,14 +125,7 @@ methodmap Entity
 	// Creates a history entry regardless of whether we already are in our original team or not
 	public void ChangeToOriginalTeam()
 	{
-		if (this.TeamCount > 0)
-		{
-			this.SetTeam(this.GetTeamInternal(0));
-		}
-		else
-		{
-			this.SetTeam(TF2_GetEntityTeam(this.Ref));
-		}
+		this.SetTeam(this.GetOriginalTeam());
 	}
 	
 	public void ResetTeam()
@@ -150,6 +143,11 @@ methodmap Entity
 			// Ensure that every `SetTeam` call is paired with a `ResetTeam` call.
 			SetFailState("Array index out-of-bounds (index %d, limit %d)", index, sizeof(EntityProperties::teamHistory));
 		}
+	}
+	
+	public TFTeam GetOriginalTeam()
+	{
+		return this.TeamCount > 0 ? this.GetTeamInternal(0) : TF2_GetEntityTeam(this.Ref);
 	}
 	
 	public TFTeam GetTeamInternal(int index)

--- a/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
@@ -110,9 +110,6 @@ void SDKHooks_OnEntityCreated(int entity, const char[] classname)
 // CTFPlayerShared::OnPreDataChanged
 static void SDKHookCB_Client_PreThink(int client)
 {
-	if (IsTruceActive())
-		return;
-	
 	// Disable radius buffs like Buff Banner or King Rune
 	Entity(client).ChangeToSpectator();
 }
@@ -120,24 +117,18 @@ static void SDKHookCB_Client_PreThink(int client)
 // CTFPlayerShared::OnPreDataChanged
 static void SDKHookCB_Client_PreThinkPost(int client)
 {
-	if (IsTruceActive())
-		return;
-	
 	Entity(client).ResetTeam();
 }
 
 // CTFWeaponBase::ItemPostFrame
 static void SDKHookCB_Client_PostThink(int client)
 {
-	if (IsTruceActive())
-		return;
-	
 	// CTFPlayer::DoTauntAttack
 	if (TF2_IsPlayerInCondition(client, TFCond_Taunting))
 	{
 		g_postThinkType = PostThinkType_Spectator;
 		
-		// Allows taunt kill work on both teams
+		// Allows taunt kills to work on both teams
 		Entity(client).ChangeToSpectator();
 		return;
 	}
@@ -184,9 +175,6 @@ static void SDKHookCB_Client_PostThink(int client)
 // CTFWeaponBase::ItemPostFrame
 static void SDKHookCB_Client_PostThinkPost(int client)
 {
-	if (IsTruceActive())
-		return;
-	
 	// Change everything back to how it was accordingly
 	switch (g_postThinkType)
 	{
@@ -212,9 +200,6 @@ static void SDKHookCB_Client_PostThinkPost(int client)
 
 static Action SDKHookCB_Client_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype)
 {
-	if (IsTruceActive())
-		return Plugin_Continue;
-	
 	if (victim == attacker)
 		return Plugin_Continue;
 	
@@ -237,9 +222,6 @@ static Action SDKHookCB_Client_OnTakeDamage(int victim, int &attacker, int &infl
 
 static void SDKHookCB_Client_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype)
 {
-	if (IsTruceActive())
-		return;
-	
 	if (victim == attacker)
 		return;
 	
@@ -258,9 +240,6 @@ static void SDKHookCB_Client_OnTakeDamagePost(int victim, int attacker, int infl
 
 static Action SDKHookCB_Client_SetTransmit(int entity, int client)
 {
-	if (IsTruceActive())
-		return Plugin_Continue;
-	
 	// Don't transmit invisible spies to living players
 	if (entity == client || !IsPlayerAlive(client))
 		return Plugin_Continue;
@@ -273,9 +252,6 @@ static Action SDKHookCB_Client_SetTransmit(int entity, int client)
 
 static Action SDKHookCB_ObjectDispenser_StartTouch(int entity, int other)
 {
-	if (IsTruceActive())
-		return Plugin_Continue;
-	
 	if (IsEntityClient(other) && !IsObjectFriendly(entity, other))
 	{
 		Entity(other).ChangeToSpectator();
@@ -286,9 +262,6 @@ static Action SDKHookCB_ObjectDispenser_StartTouch(int entity, int other)
 
 static void SDKHookCB_ObjectDispenser_StartTouchPost(int entity, int other)
 {
-	if (IsTruceActive())
-		return;
-	
 	if (IsEntityClient(other) && !IsObjectFriendly(entity, other))
 	{
 		Entity(other).ResetTeam();
@@ -297,9 +270,6 @@ static void SDKHookCB_ObjectDispenser_StartTouchPost(int entity, int other)
 
 static void SDKHookCB_Object_SpawnPost(int entity)
 {
-	if (IsTruceActive())
-		return;
-	
 	// Enable collisions for both teams
 	SetVariantInt(SOLID_TO_PLAYER_YES);
 	AcceptEntityInput(entity, "SetSolidToPlayer");
@@ -307,9 +277,6 @@ static void SDKHookCB_Object_SpawnPost(int entity)
 
 static Action SDKHookCB_Projectile_Touch(int entity, int other)
 {
-	if (IsTruceActive())
-		return Plugin_Continue;
-	
 	if (other == 0)
 		return Plugin_Continue;
 	
@@ -325,9 +292,6 @@ static Action SDKHookCB_Projectile_Touch(int entity, int other)
 
 static void SDKHookCB_Projectile_TouchPost(int entity, int other)
 {
-	if (IsTruceActive())
-		return;
-	
 	if (other == 0)
 		return;
 	
@@ -341,9 +305,6 @@ static void SDKHookCB_Projectile_TouchPost(int entity, int other)
 
 static Action SDKHookCB_ProjectilePipeRemote_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype)
 {
-	if (IsTruceActive())
-		return Plugin_Continue;
-	
 	if (attacker != -1)
 	{
 		// We might already be in spectate from another hook, do not allow damaging our own pipebombs
@@ -359,9 +320,6 @@ static Action SDKHookCB_ProjectilePipeRemote_OnTakeDamage(int victim, int &attac
 
 static void SDKHookCB_ProjectilePipeRemote_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype)
 {
-	if (IsTruceActive())
-		return;
-	
 	if (attacker != -1)
 	{
 		if (FindParentOwnerEntity(victim) == attacker)
@@ -373,9 +331,6 @@ static void SDKHookCB_ProjectilePipeRemote_OnTakeDamagePost(int victim, int atta
 
 static Action SDKHookCB_FlameManager_Touch(int entity, int other)
 {
-	if (IsTruceActive())
-		return Plugin_Continue;
-	
 	int owner = FindParentOwnerEntity(entity);
 	if (IsValidEntity(owner) && owner != other)
 	{
@@ -388,9 +343,6 @@ static Action SDKHookCB_FlameManager_Touch(int entity, int other)
 
 static void SDKHookCB_FlameManager_TouchPost(int entity, int other)
 {
-	if (IsTruceActive())
-		return;
-	
 	int owner = FindParentOwnerEntity(entity);
 	if (IsValidEntity(owner) && owner != other)
 	{
@@ -400,9 +352,6 @@ static void SDKHookCB_FlameManager_TouchPost(int entity, int other)
 
 static Action SDKHookCB_GasManager_Touch(int entity, int other)
 {
-	if (IsTruceActive())
-		return Plugin_Continue;
-	
 	if (FindParentOwnerEntity(entity) == other)
 	{
 		// Do not coat ourselves in our own gas

--- a/addons/sourcemod/scripting/friendlyfire/util.sp
+++ b/addons/sourcemod/scripting/friendlyfire/util.sp
@@ -20,11 +20,6 @@
 
 static RoundState g_roundState;
 
-bool IsTruceActive()
-{
-	return GameRules_GetProp("m_bTruceActive") != 0;
-}
-
 TFTeam TF2_GetEntityTeam(int entity)
 {
 	return view_as<TFTeam>(GetEntProp(entity, Prop_Data, "m_iTeamNum"));


### PR DESCRIPTION
Currently, the Halloween truce effectively disables the plugin, which leads to inconsistent behavior. This is the result of a band-aid fix to prevent players from airblasting or knocking players during truce. Let's fix these issues the proper way, and remove all of the manual `IsTruceActive` checks.

`CTFPlayer::ApplyGenericPushbackImpulse` -> Prevents Loose Cannon, Scorch Shot, spells, etc.
`CTFWeaponBase::DeflectProjectiles` -> Prevents airblast
`CTFPlayerShared::StunPlayer` -> Prevents all stuns

All of these check for `GetEnemyTeam`.