### PR TITLE
Fix issues from round state modifications

### DIFF
--- a/addons/sourcemod/gamedata/friendlyfire.txt
+++ b/addons/sourcemod/gamedata/friendlyfire.txt
@@ -55,6 +55,13 @@
 				"linux"		"@_ZN9CTFPlayer27ApplyGenericPushbackImpulseERK6VectorPS_"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x0C\x53\x57\x8B\xF9\x8D\x8F\xE8\x1A\x00\x00"
 			}
+			"CTFPlayer::CanAttack"
+			{
+				// string: "no_attack"
+				"library"	"server"
+				"linux"		"@_ZN9CTFPlayer9CanAttackEi"
+				"windows"	"\x55\x8B\xEC\x53\x56\x8B\x35\x2A\x2A\x2A\x2A\x57\x8B\xF9\x80\xBF\xC0\x25\x00\x00\x00"
+			}
 			"CTFPlayerShared::StunPlayer"
 			{
 				// string: "player_stunned"
@@ -349,6 +356,20 @@
 					"pAttacker"
 					{
 						"type"	"cbaseentity"
+					}
+				}
+			}
+			"CTFPlayer::CanAttack"
+			{
+				"signature"	"CTFPlayer::CanAttack"
+				"callconv"	"thiscall"
+				"return"	"bool"
+				"this"		"entity"
+				"arguments"
+				{
+					"iCanAttackFlags"
+					{
+						"type"	"int"
 					}
 				}
 			}

--- a/addons/sourcemod/scripting/friendlyfire.sp
+++ b/addons/sourcemod/scripting/friendlyfire.sp
@@ -26,7 +26,7 @@
 #include <tf2utils>
 #include <pluginstatemanager>
 
-#define PLUGIN_VERSION	"1.3.1"
+#define PLUGIN_VERSION	"1.3.2"
 
 #define TICK_NEVER_THINK	-1.0
 #define TF_CUSTOM_NONE		0

--- a/addons/sourcemod/scripting/friendlyfire/dhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/dhooks.sp
@@ -46,6 +46,7 @@ void DHooks_Init()
 	PSM_AddDynamicDetourFromConf("CBaseEntity::PhysicsDispatchThink", DHookCallback_CBaseEntity_PhysicsDispatchThink_Pre, DHookCallback_CBaseEntity_PhysicsDispatchThink_Post);
 	PSM_AddDynamicDetourFromConf("CWeaponMedigun::AllowedToHealTarget", DHookCallback_CWeaponMedigun_AllowedToHealTarget_Pre, DHookCallback_CWeaponMedigun_AllowedToHealTarget_Post);
 	PSM_AddDynamicDetourFromConf("CTFPlayer::ApplyGenericPushbackImpulse", DHookCallback_CTFPlayer_ApplyGenericPushbackImpulse_Pre, DHookCallback_CTFPlayer_ApplyGenericPushbackImpulse_Post);
+	PSM_AddDynamicDetourFromConf("CTFPlayer::CanAttack", DHookCallback_CTFPlayer_CanAttack_Pre, DHookCallback_CTFPlayer_CanAttack_Post);
 	PSM_AddDynamicDetourFromConf("CTFPlayerShared::StunPlayer", DHookCallback_CTFPlayerShared_StunPlayer_Pre, DHookCallback_CTFPlayerShared_StunPlayer_Post);
 	
 	g_dhook_CBaseProjectile_CanCollideWithTeammates = PSM_AddDynamicHookFromConf("CBaseProjectile::CanCollideWithTeammates");
@@ -585,6 +586,21 @@ static MRESReturn DHookCallback_CTFPlayer_ApplyGenericPushbackImpulse_Post(int p
 	return MRES_Ignored;
 }
 
+static MRESReturn DHookCallback_CTFPlayer_CanAttack_Pre(int player, DHookReturn ret, DHookParam params)
+{
+	// Fixes the winning team not being able to use certain weapon
+	Entity(player).ChangeToOriginalTeam();
+	
+	return MRES_Ignored;
+}
+
+static MRESReturn DHookCallback_CTFPlayer_CanAttack_Post(int player, DHookReturn ret, DHookParam params)
+{
+	Entity(player).ResetTeam();
+	
+	return MRES_Ignored;
+}
+
 static MRESReturn DHookCallback_CTFPlayerShared_StunPlayer_Pre(Address shared, DHookParam params)
 {
 	if (params.IsNull(4))
@@ -618,7 +634,6 @@ static MRESReturn DHookCallback_CTFPipebombLauncher_SecondaryAttack_Pre(int weap
 	int owner = GetEntPropEnt(weapon, Prop_Send, "m_hOwnerEntity");
 	if (owner != -1)
 	{
-		SetActiveRound();
 		Entity(owner).ChangeToSpectator();
 	}
 	
@@ -642,7 +657,6 @@ static MRESReturn DHookCallback_CTFPipebombLauncher_SecondaryAttack_Post(int wea
 	int owner = GetEntPropEnt(weapon, Prop_Send, "m_hOwnerEntity");
 	if (owner != -1)
 	{
-		ResetActiveRound();
 		Entity(owner).ResetTeam();
 	}
 	

--- a/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
+++ b/addons/sourcemod/scripting/friendlyfire/sdkhooks.sp
@@ -165,7 +165,6 @@ static void SDKHookCB_Client_PostThink(int client)
 			{
 				g_postThinkType = PostThinkType_Spectator;
 				
-				SetActiveRound();
 				Entity(client).ChangeToSpectator();
 			}
 		}
@@ -181,7 +180,6 @@ static void SDKHookCB_Client_PostThinkPost(int client)
 		case PostThinkType_Spectator:
 		{
 			Entity(client).ResetTeam();
-			ResetActiveRound();
 		}
 		case PostThinkType_EnemyTeam:
 		{

--- a/addons/sourcemod/scripting/friendlyfire/util.sp
+++ b/addons/sourcemod/scripting/friendlyfire/util.sp
@@ -18,8 +18,6 @@
 #pragma newdecls required
 #pragma semicolon 1
 
-static RoundState g_roundState;
-
 TFTeam TF2_GetEntityTeam(int entity)
 {
 	return view_as<TFTeam>(GetEntProp(entity, Prop_Data, "m_iTeamNum"));
@@ -126,16 +124,4 @@ bool IsEntityBaseMelee(int entity)
 bool IsEntityBaseGrenadeProjectile(int entity)
 {
 	return HasEntProp(entity, Prop_Data, "CTFWeaponBaseGrenadeProjDetonateThink");
-}
-
-void SetActiveRound()
-{
-	g_roundState = GameRules_GetRoundState();
-	RoundState state = (GameRules_GetProp("m_nGameType") == TF_GAMETYPE_ARENA) ? RoundState_Stalemate : RoundState_RoundRunning;
-	GameRules_SetProp("m_iRoundState", view_as<int>(state));
-}
-
-void ResetActiveRound()
-{
-	GameRules_SetProp("m_iRoundState", view_as<int>(g_roundState));
 }


### PR DESCRIPTION
Certain weapons did not work for the winning team. This was because `CTFPlayer::CanAttack` wrongly assumed the player wasn't in the winning team.

#2 and #5 tried to fix the issue, but introduced unwanted behavior, which is probably what caused #19.

Now, we simply detour the mentioned function and reset the player to their original team.

Fixes #19 (hopefully)